### PR TITLE
Fallback to continuing request when instrumentation fails

### DIFF
--- a/src/browser/instrumentation.rs
+++ b/src/browser/instrumentation.rs
@@ -138,6 +138,23 @@ pub async fn instrument_js_coverage(page: Arc<Page>) -> Result<()> {
         while let Some(event) = events.next().await {
             if let Err(error) = intercept(&event).await {
                 log::error!("failed to instrument requested script: {error}");
+                page.execute(
+                    fetch::ContinueRequestParams::builder()
+                        .request_id(event.request_id.clone())
+                        .build()
+                        .map_err(|error| {
+                            anyhow!(
+                                "failed building ContinueRequestParams: {}",
+                                error
+                            )
+                        })
+                        .expect("failed to build continue request params"),
+                )
+                .await
+                .map(|_| ())
+                .expect(
+                    "failed continuing request after instrumentation failed",
+                );
             }
         }
     });


### PR DESCRIPTION
Otherwise the browser hangs indefinitely, and consequently also the test. Closes #4.
