### PR TITLE
arm64 linux build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-linux
+          - os: ubuntu-latest
+            target: aarch64-linux
+            package: aarch64-linux
           - os: macos-latest
             target: aarch64-darwin
     runs-on: ${{ matrix.os }}
@@ -27,7 +30,8 @@ jobs:
 
       - run: nix config show
       - run: nix flake check .
-      - run: nix build .
+      - name: Build package
+        run: nix build .#${{ matrix.package || 'default' }}
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,10 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-linux
             artifact: bombadil-x86_64-linux
+          - os: ubuntu-latest
+            target: aarch64-linux
+            package: aarch64-linux
+            artifact: bombadil-aarch64-linux
           - os: macos-latest
             target: aarch64-darwin
             artifact: bombadil-aarch64-darwin
@@ -59,7 +63,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Build binary
-        run: nix build .
+        run: nix build .#${{ matrix.package || 'default' }}
 
       - name: Copy binary
         run: |
@@ -139,6 +143,7 @@ jobs:
           body: ${{ needs.check-version.outputs.changelog }}
           files: |
             artifacts/bombadil-x86_64-linux/bombadil-x86_64-linux
+            artifacts/bombadil-aarch64-linux/bombadil-aarch64-linux
             artifacts/bombadil-aarch64-darwin/bombadil-aarch64-darwin
             artifacts/bombadil-types/bombadil-types.tar.gz
 

--- a/flake.nix
+++ b/flake.nix
@@ -30,13 +30,21 @@
         );
         craneLib = crane.mkLib pkgs;
         craneLibStatic = crane.mkLib pkgs.pkgsCross.musl64;
+        craneLibAarch64 = crane.mkLib pkgs.pkgsCross.aarch64-multiplatform-musl;
         bombadil = pkgs.callPackage ./nix/default.nix { inherit craneLib craneLibStatic; };
+        bombadilAarch64 = pkgs.callPackage ./nix/default.nix {
+          inherit craneLib;
+          craneLibStatic = craneLibAarch64;
+          cargoTarget = "aarch64-unknown-linux-musl";
+        };
       in
       {
         packages = {
           default = bombadil.bin;
           types = bombadil.types;
-        } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+        }
+        // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          aarch64-linux = bombadilAarch64.bin;
           docker = pkgs.callPackage ./nix/docker.nix { bombadil = self.packages.${system}.default; };
         };
 
@@ -50,41 +58,48 @@
 
         checks = {
           inherit (bombadil) clippy fmt types;
-        } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+        }
+        // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
           inherit (bombadil) tests;
         };
 
         devShells = {
-          default = pkgs.mkShell ({
-            CARGO_INSTALL_ROOT = "${toString ./.}/.cargo";
-            inputsFrom = [ self.packages.${system}.default ];
-            buildInputs = with pkgs; [
-              # Rust
-              cargo
-              rustc
-              rust-analyzer
-              rustfmt
-              crate2nix
-              cargo-insta
-              clippy
+          default = pkgs.mkShell (
+            {
+              CARGO_INSTALL_ROOT = "${toString ./.}/.cargo";
+              inputsFrom = [ self.packages.${system}.default ];
+              buildInputs =
+                with pkgs;
+                [
+                  # Rust
+                  cargo
+                  rustc
+                  rust-analyzer
+                  rustfmt
+                  crate2nix
+                  cargo-insta
+                  clippy
 
-              # Nix
-              nil
+                  # Nix
+                  nil
 
-              # TS/JS
-              typescript
-              typescript-language-server
-              esbuild
-              bun
-              biome
-            ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-              # Runtime
-              pkgs.chromium
-            ];
-          } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-            # override how chromiumoxide finds the chromium executable
-            CHROME = pkgs.lib.getExe pkgs.chromium;
-          });
+                  # TS/JS
+                  typescript
+                  typescript-language-server
+                  esbuild
+                  bun
+                  biome
+                ]
+                ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+                  # Runtime
+                  pkgs.chromium
+                ];
+            }
+            // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+              # override how chromiumoxide finds the chromium executable
+              CHROME = pkgs.lib.getExe pkgs.chromium;
+            }
+          );
         };
       }
     );

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,6 +10,7 @@
   makeFontsConf,
   craneLib,
   craneLibStatic,
+  cargoTarget ? "x86_64-unknown-linux-musl",
   darwin ? null,
 }:
 let
@@ -68,7 +69,7 @@ in
     }
     // lib.optionalAttrs stdenv.isLinux {
       cargoArtifacts = cargoArtifactsStatic;
-      CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
+      CARGO_BUILD_TARGET = cargoTarget;
       CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
     }
     // lib.optionalAttrs stdenv.isDarwin {


### PR DESCRIPTION
This adds a new derivation for cross-compiling aarch64-linux from x86-linux using a specific package set, and uses that in CI and release.