### PR TITLE
Fix link to contribution guide in the getting started page

### DIFF
--- a/docs/manual/src/02-getting-started.md
+++ b/docs/manual/src/02-getting-started.md
@@ -81,7 +81,7 @@ Not yet available, but coming soon:
 * Docker images
 * a GitHub Action, ready to be used in your CI configuration
 
-If you want to compile from source, see [Contributing](https://github.com/antithesishq/bombadil/tree/main/docs/contributing.md).
+If you want to compile from source, see [Contributing](https://github.com/antithesishq/bombadil/tree/main/docs/development/contributing.md).
 
 ## TypeScript support
 


### PR DESCRIPTION
Link currently points to the wrong page

<img width="1582" height="1031" alt="image" src="https://github.com/user-attachments/assets/8b8f6631-5f17-4fe0-a255-928644deeba9" />
