### PR TITLE
Include snapshots in trace

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -237,6 +237,7 @@ async fn test(
                 Ok(Some(bombadil::runner::RunEvent::NewState {
                     state,
                     last_action,
+                    snapshots,
                     violations,
                 })) => {
                     let has_violations = !violations.is_empty();
@@ -249,7 +250,9 @@ async fn test(
                         );
                     }
 
-                    writer.write(last_action, state, violations).await?;
+                    writer
+                        .write(last_action, state, snapshots, violations)
+                        .await?;
 
                     if has_violations && shared_options.exit_on_violation {
                         break Ok(Some(2));

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -26,6 +26,7 @@ pub enum RunEvent {
     NewState {
         state: BrowserState,
         last_action: Option<BrowserAction>,
+        snapshots: Vec<Snapshot>,
         violations: Vec<PropertyViolation>,
     },
 }
@@ -158,7 +159,7 @@ impl Runner {
                                     value.value
                                 );
                             }
-                            let step_result = verifier.step::<crate::specification::js::JsAction>(snapshots, state.timestamp).await?;
+                            let step_result = verifier.step::<crate::specification::js::JsAction>(snapshots.clone(), state.timestamp).await?;
 
                             // Convert JsAction tree to BrowserAction tree
                             let action_tree = step_result.actions.try_map(&mut |js_action| {
@@ -200,6 +201,7 @@ impl Runner {
                             events.send(RunEvent::NewState {
                                 state,
                                 last_action,
+                                snapshots,
                                 violations,
                             })?;
                             if has_violations && options.stop_on_violation {

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use crate::{
     browser::actions::BrowserAction,
-    specification::{ltl, render},
+    specification::{ltl, render, verifier::Snapshot},
 };
 
 pub mod writer;
@@ -18,6 +18,7 @@ pub struct TraceEntry {
     pub hash_current: Option<u64>,
     pub action: Option<BrowserAction>,
     pub screenshot: PathBuf,
+    pub snapshots: Vec<Snapshot>,
     pub violations: Vec<PropertyViolation>,
 }
 

--- a/src/trace/writer.rs
+++ b/src/trace/writer.rs
@@ -6,6 +6,7 @@ use tokio::{fs::File, io::AsyncWriteExt};
 
 use crate::{
     browser::{actions::BrowserAction, state::BrowserState},
+    specification::verifier::Snapshot,
     trace::{PropertyViolation, TraceEntry},
 };
 
@@ -40,6 +41,7 @@ impl TraceWriter {
         &mut self,
         last_action: Option<BrowserAction>,
         state: BrowserState,
+        snapshots: Vec<Snapshot>,
         violations: Vec<PropertyViolation>,
     ) -> Result<()> {
         let screenshot_path = self.screenshots_path.join(format!(
@@ -59,6 +61,7 @@ impl TraceWriter {
             hash_current: state.transition_hash,
             action: last_action,
             screenshot: screenshot_path,
+            snapshots,
             violations,
         };
 


### PR DESCRIPTION
Snapshots -- name-value pairs, where name is optional but usually 
taken from the source code -- have so far only been printed in logs,
not included in the test output `trace.jsonl`. This change includes
snapshots in the trace format so that we can build better debugging
tools later on.

