### PR TITLE
docs: introduction -  line edits + suggestions

### DIFF
--- a/docs/manual/src/01-introduction.md
+++ b/docs/manual/src/01-introduction.md
@@ -4,33 +4,32 @@ title: The Bombadil Manual
 
 # Introduction
 
-Bombadil is property-based testing for web UIs, autonomously exploring and
-validating correctness properties, *finding harder bugs earlier*. It runs in
+Bombadil is property-based testing <!-- TODO: link back to property based testing docs -->for web UIs. It autonomously explores and
+validates correctness properties, *finding harder bugs earlier*. It runs in
 your local developer environment, in CI, and inside
 [Antithesis](https://antithesis.com/).
 
 ## Why Bombadil?
 
-Or rather, *why property-based testing?* Because example-based testing,
-especially in the area of browser testing, is costly and limited:
+Or rather, *why property-based testing?* <!-- TODO: link back to property based testing docs --> Because example-based testing,
+especially when browser testing, is costly and limited:
 
 * Costly, because maintaining suites of Playwright or Cypress tests takes a lot
-  of work. And even in the days of AI agents writing and updating those tests
-  for you, they easily break and require your attention.
-* Limited, in that they only test very small parts of the state space. A bunch
+  of work. Even in the age of AI, tests written and updated by agents can easily break and require your attention. <!-- comment: you may want to specify and use e.g. “generative agents” or whatever word feels most appropriate if you want to be extremely clear --> 
+* Limited, in that they only test very small parts of the state space; a bunch
   of happy cases, a set of regression tests, and maybe even some error handling
   cases that are important. But what about everything else? All the stuff you
-  or the agent didn't think about testing?
+  or the agent didn't think about testing? <!-- TODO: combine final two sentences -->
 
-This is where property-based testing, or *fuzzing* if you will, comes into
+This is where property-based testing, or *fuzzing* <!-- TODO: link back to property based testing docs --> if you will, comes into
 play. By randomly and systematically searching the state space, Bombadil
 behaves in ways you didn't think about testing for. Unexpected sequences of
-actions, weird timings, strange inputs that you forgot could be entered.
+actions, weird timings, strange inputs that you forgot could be entered. <!-- TODO: combine final two sentences -->
 
 ## How it works
 
 Instead of describing "what good looks like" in terms of fixed test cases, you
-express general properties of your system, how it should behave in all cases.
+express general properties of your system, defining how it should behave in all cases.
 Bombadil checks each property as it explores your system in its chaotic ways,
 reporting back any violations.
 
@@ -41,7 +40,7 @@ validate your system's logic in custom ways --- or be imported from the
 [defaults](#default-properties-and-action-generators) provided by Bombadil. It
 doesn't matter how the application is built --- if it's a single-page app,
 server-side rendered, or even static HTML --- Bombadil tests anything that uses
-the DOM.
+the DOM. <!-- TODO: rewrite final two sentences for conciseness -->
 
 Conceptually, it runs in a loop doing the following:
 
@@ -49,10 +48,10 @@ Conceptually, it runs in a loop doing the following:
 2. Checks all properties against the current state, recording violations[^exit]
 3. Selects the next action based on the current state, and performs it
 4. Waits for the next event (page navigation, DOM mutation, or timeout)
-5. *Goes to step 1*
+5. *Returns to step 1*
 
 Bombadil itself decides what is an interesting event and when to capture state.
-The specification author provides the properties and actions, Bombadil does the
-rest.
+You provide the properties and actions, Bombadil does the
+rest!
 
 [^exit]: You can also configure Bombadil to exit on the first found violation.


### PR DESCRIPTION
No major issues with clarity at all, your writing was very easy to follow! Edits are mostly to refine the language for succinctness, flow and to formalize the writing a bit; helping it read less like a series of notes and making sure any hanging phrases are combined into full sentences. I also suggested adding some links. I elaborated on some of the edits that weren't self explanatory below:

**Link back to Antithesis docs**

> Bombadil is [property-based testing](https://antithesis.com/docs/resources/property_based_testing/)

> why [property-based testing?](https://antithesis.com/docs/resources/property_based_testing/)

> This is where property-based testing, or [fuzzing ](https://antithesis.com/docs/resources/property_based_testing/#related-terms)

Are you open to linking back to the Antithesis site where it's relevant (e.g. for terms that are defined on the site)? I recommend doing so — it's helpful for users and great for SEO. But I also noted that the team would like this set of docs to stand alone wrt Antithesis docs, so if that's the case, feel free to disregard this edit. 

**Combine/rewrite sentences**

> But what about everything else? All the stuff you or the agent didn’t think about testing?

A couple of suggested options here:

_1. But what about everything else — like all the stuff you or the agent didn't think about testing?
2. But what about everything else — namely, all the stuff you or the agent didn't think about testing?_

> By randomly and systematically searching the state space, Bombadil behaves in ways you didn’t think about testing for. Unexpected sequences of actions, weird timings, strange inputs that you forgot could be entered.

Suggested options:

_1. (shorter): By randomly and systematically searching the state space, Bombadil behaves in ways you didn't think about testing for; unexpected sequences of actions, weird timings, strange inputs that you forgot could be entered, etc.
2. (longer): By randomly and systematically searching the state space, Bombadil behaves in ways you didn't think about testing for. It can account for unexpected sequences of actions, weird timings, strange inputs that you forgot could be entered, etc._

> These can be domain-specific — to exercise and validate your system’s logic in custom ways — or be imported from the [defaults](https://antithesishq.github.io/bombadil/3-specification-language.html#default-properties-and-action-generators) provided by Bombadil. It doesn’t matter how the application is built — if it’s a single-page app, server-side rendered, or even static HTML — Bombadil tests anything that uses the DOM.

Suggested option: 

_These can be domain-specific --- to exercise and validate your system's logic in custom ways --- or be imported from Bombadil’s [defaults](https://github.com/antithesishq/bombadil/blob/main/docs/manual/src/01-introduction.md#default-properties-and-action-generators). Bombadil tests anything that uses the DOM, no matter how it’s built. This includes single-page app, server-side rendered, and even static HTML._ 

> The specification author provides the properties and actions, Bombadil does the rest.

Changed to: 

_You provide the properties and actions, Bombadil does the rest!_

Alternative option (in case more specificity is needed): 

_You (the specification author) provide the properties and actions, Bombadil does the rest!_

The last edit suggestion is totally a matter of style -- it's an opportunity to inject some personality/pithiness. If it feels totally off in tone, feel free to disregard. 