### PR TITLE
Fix cached violation bug on continued stepping

### DIFF
--- a/lib/bombadil/src/runner.rs
+++ b/lib/bombadil/src/runner.rs
@@ -143,7 +143,6 @@ impl Runner {
 
                         let mut violations =
                             Vec::with_capacity(step_result.properties.len());
-                        let mut all_properties_definite = true;
                         for (name, value) in step_result.properties {
                             match value {
                                 PropertyValue::False(violation) => {
@@ -152,12 +151,8 @@ impl Runner {
                                         violation,
                                     });
                                 }
-                                PropertyValue::Residual => {
-                                    all_properties_definite = false;
-                                }
-                                PropertyValue::True => {
-                                    // Property is satisfied
-                                }
+                                PropertyValue::Residual
+                                | PropertyValue::True => {}
                             }
                         }
                         let has_violations = !violations.is_empty();
@@ -196,7 +191,7 @@ impl Runner {
                         if has_violations && options.stop_on_violation {
                             return Ok(None);
                         }
-                        if all_properties_definite {
+                        if !step_result.has_pending {
                             log::info!("all properties are definite, stopping");
                             return Ok(None);
                         }

--- a/lib/bombadil/src/specification/ltl.rs
+++ b/lib/bombadil/src/specification/ltl.rs
@@ -3,6 +3,18 @@ use std::time::{Duration, SystemTime};
 use crate::specification::result::{Result, SpecificationError};
 use serde::Serialize;
 
+fn combine_options<T: Clone>(
+    left: Option<T>,
+    right: Option<T>,
+    combine: fn(T, T) -> T,
+) -> Option<T> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(combine(left, right)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
 /// A formula in negation normal form (NNF), up to thunks. Note that `Implies` is preserved for
 /// better error messages.
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -70,7 +82,7 @@ pub type Time = SystemTime;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value<Function> {
     True,
-    False(Violation<Function>),
+    False(Violation<Function>, Option<Residual<Function>>),
     Residual(Residual<Function>),
 }
 
@@ -242,10 +254,13 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
             Formula::Pure { value, pretty } => Ok(if *value {
                 Value::True
             } else {
-                Value::False(Violation::False {
-                    time,
-                    condition: pretty.clone(),
-                })
+                Value::False(
+                    Violation::False {
+                        time,
+                        condition: pretty.clone(),
+                    },
+                    None,
+                )
             }),
             Formula::Thunk { function, negated } => {
                 let formula = (self.evaluate_thunk)(function, *negated)?;
@@ -305,22 +320,51 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
         left: &Value<Function>,
         right: &Value<Function>,
     ) -> Value<Function> {
+        fn combine_and<F: Clone>(
+            left: Residual<F>,
+            right: Residual<F>,
+        ) -> Residual<F> {
+            Residual::And {
+                left: Box::new(left),
+                right: Box::new(right),
+            }
+        }
+
         match (left, right) {
             (Value::True, right) => right.clone(),
             (left, Value::True) => left.clone(),
-            (Value::False(left), Value::False(right)) => {
-                Value::False(Violation::And {
-                    left: Box::new(left.clone()),
-                    right: Box::new(right.clone()),
-                })
+            (
+                Value::False(left_violation, left_continuation),
+                Value::False(right_violation, right_continuation),
+            ) => Value::False(
+                Violation::And {
+                    left: Box::new(left_violation.clone()),
+                    right: Box::new(right_violation.clone()),
+                },
+                combine_options(
+                    left_continuation.clone(),
+                    right_continuation.clone(),
+                    combine_and,
+                ),
+            ),
+            (
+                Value::Residual(residual),
+                Value::False(violation, continuation),
+            )
+            | (
+                Value::False(violation, continuation),
+                Value::Residual(residual),
+            ) => {
+                let continuation = match continuation {
+                    Some(continuation) => {
+                        combine_and(residual.clone(), continuation.clone())
+                    }
+                    None => residual.clone(),
+                };
+                Value::False(violation.clone(), Some(continuation))
             }
-            (_, Value::False(violation)) => Value::False(violation.clone()),
-            (Value::False(violation), _) => Value::False(violation.clone()),
             (Value::Residual(left), Value::Residual(right)) => {
-                Value::Residual(Residual::And {
-                    left: Box::new(left.clone()),
-                    right: Box::new(right.clone()),
-                })
+                Value::Residual(combine_and(left.clone(), right.clone()))
             }
         }
     }
@@ -331,16 +375,27 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
         right: &Value<Function>,
     ) -> Value<Function> {
         match (left, right) {
-            (Value::False(left), Value::False(right)) => {
-                Value::False(Violation::Or {
-                    left: Box::new(left.clone()),
-                    right: Box::new(right.clone()),
-                })
-            }
+            (
+                Value::False(left_violation, left_continuation),
+                Value::False(right_violation, right_continuation),
+            ) => Value::False(
+                Violation::Or {
+                    left: Box::new(left_violation.clone()),
+                    right: Box::new(right_violation.clone()),
+                },
+                combine_options(
+                    left_continuation.clone(),
+                    right_continuation.clone(),
+                    |left, right| Residual::Or {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    },
+                ),
+            ),
             (Value::True, _) => Value::True,
             (_, Value::True) => Value::True,
-            (left, Value::False(_)) => left.clone(),
-            (Value::False(_), right) => right.clone(),
+            (left, Value::False(_, _)) => left.clone(),
+            (Value::False(_, _), right) => right.clone(),
             (Value::Residual(left), Value::Residual(right)) => {
                 Value::Residual(Residual::Or {
                     left: Box::new(left.clone()),
@@ -357,12 +412,19 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
         right: &Value<Function>,
     ) -> Value<Function> {
         match (left, right) {
-            (Value::False(_), _) => Value::True,
-            (Value::True, Value::False(violation)) => {
-                Value::False(Violation::Implies {
-                    left: left_formula.clone(),
-                    right: Box::new(violation.clone()),
-                })
+            (Value::False(_, _), _) => Value::True,
+            (Value::True, Value::False(violation, continuation)) => {
+                Value::False(
+                    Violation::Implies {
+                        left: left_formula.clone(),
+                        right: Box::new(violation.clone()),
+                    },
+                    continuation.as_ref().map(|c| Residual::Implies {
+                        left_formula: left_formula.clone(),
+                        left: Box::new(Residual::True),
+                        right: Box::new(c.clone()),
+                    }),
+                )
             }
             (Value::True, Value::True) => Value::True,
             (Value::True, Value::Residual(right)) => {
@@ -373,7 +435,7 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
                 })
             }
             (Value::Residual(_), Value::True) => Value::True,
-            (Value::Residual(left), Value::False(violation)) => {
+            (Value::Residual(left), Value::False(violation, _)) => {
                 Value::Residual(Residual::Implies {
                     left_formula: left_formula.clone(),
                     left: Box::new(left.clone()),
@@ -412,22 +474,39 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
             Leaning::AssumeTrue,
         );
 
+        let wrap_and_always = |inner: Residual<Function>,
+                               always: Residual<Function>|
+         -> Residual<Function> {
+            Residual::AndAlways {
+                subformula: subformula.clone(),
+                start,
+                end,
+                left: Box::new(inner),
+                right: Box::new(always),
+            }
+        };
+
         Ok(match self.evaluate(&subformula, time)? {
             Value::True => Value::Residual(residual),
-            Value::False(violation) => Value::False(Violation::Always {
-                violation: Box::new(violation),
-                subformula: subformula.clone(),
-                start,
-                end,
-                time,
-            }),
-            Value::Residual(left) => Value::Residual(Residual::AndAlways {
-                subformula: subformula.clone(),
-                start,
-                end,
-                left: Box::new(left),
-                right: Box::new(residual),
-            }),
+            Value::False(violation, continuation) => {
+                let continuation = match continuation {
+                    Some(inner) => wrap_and_always(inner, residual),
+                    None => residual,
+                };
+                Value::False(
+                    Violation::Always {
+                        violation: Box::new(violation),
+                        subformula: subformula.clone(),
+                        start,
+                        end,
+                        time,
+                    },
+                    Some(continuation),
+                )
+            }
+            Value::Residual(inner) => {
+                Value::Residual(wrap_and_always(inner, residual))
+            }
         })
     }
 
@@ -446,22 +525,28 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
             return Ok(Value::True);
         }
 
+        let wrap_and_always = |inner: Residual<Function>,
+                               always: Residual<Function>|
+         -> Residual<Function> {
+            Residual::AndAlways {
+                subformula: subformula.clone(),
+                start,
+                end,
+                left: Box::new(inner),
+                right: Box::new(always),
+            }
+        };
+
+        fn pending_residual<F>(value: &Value<F>) -> Option<&Residual<F>> {
+            match value {
+                Value::Residual(residual) => Some(residual),
+                Value::False(_, Some(continuation)) => Some(continuation),
+                _ => None,
+            }
+        }
+
         Ok(match (left, right) {
             (Value::True, Value::True) => Value::True,
-            (Value::False(violation), _) => Value::False(Violation::Always {
-                violation: Box::new(violation.clone()),
-                subformula,
-                start,
-                end,
-                time,
-            }),
-            (_, Value::False(violation)) => Value::False(Violation::Always {
-                violation: Box::new(violation.clone()),
-                subformula,
-                start,
-                end,
-                time,
-            }),
             (Value::Residual(left), Value::True) => {
                 Value::Residual(Residual::AndAlways {
                     subformula,
@@ -489,6 +574,43 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
                     right: Box::new(right),
                 })
             }
+            (left, right) => {
+                let always_residual = Residual::Derived(
+                    Derived::Always {
+                        subformula: subformula.clone(),
+                        start,
+                        end,
+                    },
+                    Leaning::AssumeTrue,
+                );
+                let inner = combine_options(
+                    pending_residual(&left).cloned(),
+                    pending_residual(&right).cloned(),
+                    |left, right| Residual::And {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    },
+                );
+                let continuation = match inner {
+                    Some(inner) => wrap_and_always(inner, always_residual),
+                    None => always_residual,
+                };
+                let violation = match (&left, &right) {
+                    (Value::False(violation, _), _) => violation,
+                    (_, Value::False(violation, _)) => violation,
+                    _ => unreachable!(),
+                };
+                Value::False(
+                    Violation::Always {
+                        violation: Box::new(violation.clone()),
+                        subformula,
+                        start,
+                        end,
+                        time,
+                    },
+                    Some(continuation),
+                )
+            }
         })
     }
 
@@ -502,10 +624,13 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
         if let Some(end) = end
             && end < time
         {
-            return Ok(Value::False(Violation::Eventually {
-                subformula: subformula.clone(),
-                reason: EventuallyViolation::TimedOut(time),
-            }));
+            return Ok(Value::False(
+                Violation::Eventually {
+                    subformula: subformula.clone(),
+                    reason: EventuallyViolation::TimedOut(time),
+                },
+                None,
+            ));
         }
 
         let residual = Residual::Derived(
@@ -522,7 +647,7 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
 
         Ok(match self.evaluate(&subformula, time)? {
             Value::True => Value::True,
-            Value::False(_violation) => Value::Residual(residual),
+            Value::False(_violation, _) => Value::Residual(residual),
             Value::Residual(left) => Value::Residual(Residual::OrEventually {
                 subformula,
                 end,
@@ -545,26 +670,29 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
         if let Some(end) = end
             && end < time
         {
-            return Ok(Value::False(Violation::Eventually {
-                subformula,
-                reason: EventuallyViolation::TimedOut(time),
-            }));
+            return Ok(Value::False(
+                Violation::Eventually {
+                    subformula,
+                    reason: EventuallyViolation::TimedOut(time),
+                },
+                None,
+            ));
         }
 
         Ok(match (left, right) {
             (Value::True, _) => Value::True,
             (_, Value::True) => Value::True,
-            (Value::False(_), Value::False(right)) => {
+            (Value::False(_, _), Value::False(right, _)) => {
                 // NOTE: We ignore the left-side violation in `eventually` in
                 // order to not build up a giant violation tree of all the
                 // non-evidence we've seen (e.g. X was not true in state 1 and
                 // X was not true in state 2 and ...).
-                Value::False(right.clone()) // TODO: should this be wrapped in Violation::Eventually?
+                Value::False(right.clone(), None) // TODO: should this be wrapped in Violation::Eventually?
             }
-            (Value::False(_), Value::Residual(residual)) => {
+            (Value::False(_, _), Value::Residual(residual)) => {
                 Value::Residual(residual.clone())
             }
-            (Value::Residual(residual), Value::False(_)) => {
+            (Value::Residual(residual), Value::False(_, _)) => {
                 Value::Residual(residual.clone())
             }
             (Value::Residual(left), Value::Residual(right)) => {
@@ -586,7 +714,7 @@ impl<'a, Function: Clone> Evaluator<'a, Function> {
     ) -> Result<Value<Function>> {
         Ok(match residual {
             Residual::True => Value::True,
-            Residual::False(violation) => Value::False(violation.clone()),
+            Residual::False(violation) => Value::False(violation.clone(), None),
             Residual::And { left, right } => {
                 let left = self.step(left, time)?;
                 let right = self.step(right, time)?;

--- a/lib/bombadil/src/specification/ltl_equivalences.rs
+++ b/lib/bombadil/src/specification/ltl_equivalences.rs
@@ -103,16 +103,16 @@ fn assert_values_eq<Function: Clone + PartialEq + std::fmt::Debug>(
     time: Time,
     mode: ValueEqMode,
 ) {
-    match (value_left, value_right) {
+    match (&value_left, &value_right) {
         (Value::True, Value::True) => {}
-        (Value::False(left), Value::False(right)) => {
+        (Value::False(left, _), Value::False(right, _)) => {
             if mode == ValueEqMode::Strict {
                 assert_eq!(left, right);
             }
         }
         (Value::Residual(left), Value::Residual(right)) => {
-            let default_left = stop_default(&left, time);
-            let default_right = stop_default(&right, time);
+            let default_left = stop_default(left, time);
+            let default_right = stop_default(right, time);
             match mode {
                 ValueEqMode::Strict => assert_eq!(default_left, default_right),
                 ValueEqMode::UpToViolations => {
@@ -131,6 +131,16 @@ fn assert_values_eq<Function: Clone + PartialEq + std::fmt::Debug>(
             }
         }
         (left, right) => panic!("\n{:?}\n\n!=\n\n{:?}\n", left, right),
+    }
+}
+
+fn next_residual<Function: Clone>(
+    value: &Value<Function>,
+) -> Option<Residual<Function>> {
+    match value {
+        Value::Residual(r) => Some(r.clone()),
+        Value::False(_, Some(c)) => Some(c.clone()),
+        _ => None,
     }
 }
 
@@ -175,13 +185,15 @@ fn check_equivalence(
         *current.borrow_mut() += 1;
         time = time.checked_add(Duration::from_millis(1)).unwrap();
 
-        if let Value::Residual(left) = &value_left
-            && let Value::Residual(right) = &value_right
-        {
-            value_left = evaluator.step(left, time).unwrap();
-            value_right = evaluator.step(right, time).unwrap();
-        } else {
-            break;
+        let next_left = next_residual(&value_left);
+        let next_right = next_residual(&value_right);
+
+        match (next_left, next_right) {
+            (Some(left), Some(right)) => {
+                value_left = evaluator.step(&left, time).unwrap();
+                value_right = evaluator.step(&right, time).unwrap();
+            }
+            _ => break,
         }
     }
 

--- a/lib/bombadil/src/specification/verifier.rs
+++ b/lib/bombadil/src/specification/verifier.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::specification::js::{BombadilExports, Extractors, RuntimeFunction};
-use crate::specification::ltl::{Evaluator, Formula, Residual, Violation};
+use crate::specification::ltl::{Evaluator, Formula, Residual};
 use crate::specification::result::Result;
 use crate::specification::syntax::Syntax;
 use crate::specification::{ltl, result::SpecificationError};
@@ -21,6 +21,7 @@ use serde_json as json;
 pub struct StepResult<A> {
     pub properties: Vec<(String, ltl::Value<RuntimeFunction>)>,
     pub actions: Tree<A>,
+    pub has_pending: bool,
 }
 
 pub struct Verifier {
@@ -308,10 +309,8 @@ impl Verifier {
                 PropertyState::Residual(residual) => {
                     evaluator.step(residual, time)?
                 }
-                PropertyState::DefinitelyTrue => ltl::Value::True,
-                PropertyState::DefinitelyFalse(violation) => {
-                    ltl::Value::False(violation.clone())
-                }
+                PropertyState::DefinitelyTrue
+                | PropertyState::DefinitelyFalse => continue,
             };
             result_properties.push((
                 property.name.clone(),
@@ -320,10 +319,12 @@ impl Verifier {
                         property.state = PropertyState::DefinitelyTrue;
                         ltl::Value::True
                     }
-                    ltl::Value::False(violation) => {
-                        property.state =
-                            PropertyState::DefinitelyFalse(violation.clone());
-                        ltl::Value::False(violation)
+                    ltl::Value::False(violation, continuation) => {
+                        property.state = match continuation {
+                            Some(residual) => PropertyState::Residual(residual),
+                            None => PropertyState::DefinitelyFalse,
+                        };
+                        ltl::Value::False(violation, None)
                     }
                     ltl::Value::Residual(residual) => {
                         property.state =
@@ -343,9 +344,17 @@ impl Verifier {
             branches: generator_branches,
         };
 
+        let has_pending = self.properties.values().any(|p| {
+            matches!(
+                &p.state,
+                PropertyState::Initial(_) | PropertyState::Residual(_)
+            )
+        });
+
         Ok(StepResult {
             properties: result_properties,
             actions: action_tree,
+            has_pending,
         })
     }
 }
@@ -364,7 +373,7 @@ enum PropertyState {
     Initial(Formula<RuntimeFunction>),
     Residual(Residual<RuntimeFunction>),
     DefinitelyTrue,
-    DefinitelyFalse(Violation<RuntimeFunction>),
+    DefinitelyFalse,
 }
 
 #[derive(Debug, Clone)]
@@ -689,11 +698,14 @@ mod tests {
             if i == 100 {
                 assert!(matches!(
                     value,
-                    ltl::Value::False(Violation::Always {
-                        violation: _,
-                        subformula: _,
-                        ..
-                    })
+                    ltl::Value::False(
+                        ltl::Violation::Always {
+                            violation: _,
+                            subformula: _,
+                            ..
+                        },
+                        _
+                    )
                 ))
             } else {
                 match value {
@@ -707,6 +719,26 @@ mod tests {
                 }
             }
         }
+
+        // After the violation at i=100, the property should reset to
+        // Residual when given a passing value.
+        let time = time_at(0);
+        let result: StepResult<Snapshot> = verifier
+            .step(
+                &[Snapshot {
+                    name: None,
+                    value: json::json!(0),
+                }],
+                time,
+            )
+            .unwrap();
+        let (name, value) = result.properties.first().unwrap();
+        assert_eq!(*name, "my_prop");
+        assert!(
+            matches!(value, ltl::Value::Residual(_)),
+            "expected Residual after reset, got: {:?}",
+            value,
+        );
     }
 
     #[test]
@@ -740,21 +772,28 @@ mod tests {
                 )
                 .unwrap();
 
-            let (name, value) = result.properties.first().unwrap();
-            assert_eq!(*name, "my_prop");
+            if let Some((name, value)) = result.properties.first() {
+                assert_eq!(*name, "my_prop");
 
-            if i < 4 {
-                match value {
-                    ltl::Value::Residual(residual) => {
-                        match stop_default(residual, time) {
-                            Some(StopDefault::True) => {}
-                            _ => panic!("should have a true stop default"),
+                if i < 4 {
+                    match value {
+                        ltl::Value::Residual(residual) => {
+                            match stop_default(residual, time) {
+                                Some(StopDefault::True) => {}
+                                _ => {
+                                    panic!("should have a true stop default")
+                                }
+                            }
+                        }
+                        other => {
+                            panic!("should be residual but was: {:?}", other)
                         }
                     }
-                    other => panic!("should be residual but was: {:?}", other),
+                } else {
+                    assert!(matches!(value, ltl::Value::True));
                 }
             } else {
-                assert!(matches!(value, ltl::Value::True));
+                assert!(i > 4, "property should still be pending at i={}", i);
             }
         }
     }
@@ -859,22 +898,255 @@ mod tests {
                 )
                 .unwrap();
 
-            let (name, value) = result.properties.first().unwrap();
-            assert_eq!(*name, "my_prop");
+            if let Some((name, value)) = result.properties.first() {
+                assert_eq!(*name, "my_prop");
 
-            if i < 4 {
-                match value {
-                    ltl::Value::Residual(residual) => {
-                        match stop_default(residual, time) {
-                            Some(StopDefault::False(_)) => {}
-                            _ => panic!("should have a false stop default"),
+                if i < 4 {
+                    match value {
+                        ltl::Value::Residual(residual) => {
+                            match stop_default(residual, time) {
+                                Some(StopDefault::False(_)) => {}
+                                _ => {
+                                    panic!("should have a false stop default")
+                                }
+                            }
+                        }
+                        other => {
+                            panic!("should be residual but was: {:?}", other)
                         }
                     }
-                    other => panic!("should be residual but was: {:?}", other),
+                } else {
+                    assert!(matches!(value, ltl::Value::False(_, _)));
                 }
             } else {
-                assert!(matches!(value, ltl::Value::False(_)));
+                assert!(i > 4, "property should still be pending at i={}", i);
             }
         }
+    }
+
+    #[test]
+    fn test_always_resets_after_violation() {
+        let mut verifier = verifier(
+            r#"
+            import { extract, always, actions } from "@antithesishq/bombadil";
+            export const _actions = actions(() => []);
+
+            const foo = extract((state) => state.foo);
+
+            export const my_prop = always(() => foo.current < 5);
+            "#,
+        );
+
+        let time_at = |i: u64| {
+            SystemTime::UNIX_EPOCH
+                .checked_add(Duration::from_millis(i))
+                .unwrap()
+        };
+
+        // Steps 0-4: Residual (passing)
+        for i in 0..5 {
+            let result: StepResult<Snapshot> = verifier
+                .step(
+                    &[Snapshot {
+                        name: None,
+                        value: json::json!(i),
+                    }],
+                    time_at(0),
+                )
+                .unwrap();
+            let (_, value) = result.properties.first().unwrap();
+            assert!(
+                matches!(value, ltl::Value::Residual(_)),
+                "expected Residual at i={}, got: {:?}",
+                i,
+                value,
+            );
+        }
+
+        // Step with value 5: False (violation)
+        let result: StepResult<Snapshot> = verifier
+            .step(
+                &[Snapshot {
+                    name: None,
+                    value: json::json!(5),
+                }],
+                time_at(0),
+            )
+            .unwrap();
+        let (_, value) = result.properties.first().unwrap();
+        assert!(
+            matches!(value, ltl::Value::False(_, _)),
+            "expected False at value=5, got: {:?}",
+            value,
+        );
+
+        // Step with value 0: should reset to Residual (not repeat False)
+        let result: StepResult<Snapshot> = verifier
+            .step(
+                &[Snapshot {
+                    name: None,
+                    value: json::json!(0),
+                }],
+                time_at(0),
+            )
+            .unwrap();
+        let (_, value) = result.properties.first().unwrap();
+        assert!(
+            matches!(value, ltl::Value::Residual(_)),
+            "expected Residual after reset, got: {:?}",
+            value,
+        );
+
+        // Step with value 5 again: should produce a new False
+        let result: StepResult<Snapshot> = verifier
+            .step(
+                &[Snapshot {
+                    name: None,
+                    value: json::json!(5),
+                }],
+                time_at(0),
+            )
+            .unwrap();
+        let (_, value) = result.properties.first().unwrap();
+        assert!(
+            matches!(value, ltl::Value::False(_, _)),
+            "expected new False at value=5, got: {:?}",
+            value,
+        );
+    }
+
+    #[test]
+    fn test_now_false_is_terminal() {
+        let mut verifier = verifier(
+            r#"
+            import { extract, now, actions } from "@antithesishq/bombadil";
+            export const _actions = actions(() => []);
+
+            const foo = extract((state) => state.foo);
+
+            export const my_prop = now(() => foo.current);
+            "#,
+        );
+
+        let time = SystemTime::UNIX_EPOCH;
+
+        // First step: False (no continuation)
+        let result: StepResult<Snapshot> = verifier
+            .step(
+                &[Snapshot {
+                    name: None,
+                    value: json::json!(false),
+                }],
+                time,
+            )
+            .unwrap();
+        let (name, value) = result.properties.first().unwrap();
+        assert_eq!(*name, "my_prop");
+        assert!(
+            matches!(value, ltl::Value::False(_, None)),
+            "expected terminal False, got: {:?}",
+            value,
+        );
+
+        // Subsequent step: property is settled, no result emitted
+        let result: StepResult<Snapshot> = verifier
+            .step(
+                &[Snapshot {
+                    name: None,
+                    value: json::json!(true),
+                }],
+                time,
+            )
+            .unwrap();
+        assert!(
+            result.properties.is_empty(),
+            "expected no properties after terminal False, got: {:?}",
+            result.properties,
+        );
+        assert!(!result.has_pending);
+    }
+
+    #[test]
+    fn test_always_bounded_continues_after_violation() {
+        let mut verifier = verifier(
+            r#"
+            import { extract, always, actions } from "@antithesishq/bombadil";
+            export const _actions = actions(() => []);
+
+            const foo = extract((state) => state.foo);
+
+            export const my_prop = always(() => foo.current < 10).within(5, "milliseconds");
+            "#,
+        );
+
+        let time_at = |i: u64| {
+            SystemTime::UNIX_EPOCH
+                .checked_add(Duration::from_millis(i))
+                .unwrap()
+        };
+
+        // At time 0, value 0: Residual
+        let result: StepResult<Snapshot> = verifier
+            .step(
+                &[Snapshot {
+                    name: None,
+                    value: json::json!(0),
+                }],
+                time_at(0),
+            )
+            .unwrap();
+        let (_, value) = result.properties.first().unwrap();
+        assert!(matches!(value, ltl::Value::Residual(_)));
+
+        // At time 3ms, value 10: fails the always, but has continuation
+        let result: StepResult<Snapshot> = verifier
+            .step(
+                &[Snapshot {
+                    name: None,
+                    value: json::json!(10),
+                }],
+                time_at(3),
+            )
+            .unwrap();
+        let (_, value) = result.properties.first().unwrap();
+        assert!(
+            matches!(value, ltl::Value::False(_, _)),
+            "expected False at time 3ms, got: {:?}",
+            value,
+        );
+
+        // At time 4ms, value 0: should be Residual (reset via continuation)
+        let result: StepResult<Snapshot> = verifier
+            .step(
+                &[Snapshot {
+                    name: None,
+                    value: json::json!(0),
+                }],
+                time_at(4),
+            )
+            .unwrap();
+        let (_, value) = result.properties.first().unwrap();
+        assert!(
+            matches!(value, ltl::Value::Residual(_)),
+            "expected Residual at time 4ms after reset, got: {:?}",
+            value,
+        );
+
+        // At time 6ms (past the 5ms bound): should resolve to True
+        let result: StepResult<Snapshot> = verifier
+            .step(
+                &[Snapshot {
+                    name: None,
+                    value: json::json!(0),
+                }],
+                time_at(6),
+            )
+            .unwrap();
+        let (_, value) = result.properties.first().unwrap();
+        assert!(
+            matches!(value, ltl::Value::True),
+            "expected True past the bound, got: {:?}",
+            value,
+        );
     }
 }

--- a/lib/bombadil/src/specification/worker.rs
+++ b/lib/bombadil/src/specification/worker.rs
@@ -24,12 +24,14 @@ enum Command {
 struct RawStepResult {
     properties: Vec<(String, PropertyValue)>,
     actions: Tree<json::Value>,
+    has_pending: bool,
 }
 
 #[derive(Debug, Clone)]
 pub struct StepResult<A> {
     pub properties: Vec<(String, PropertyValue)>,
     pub actions: Tree<A>,
+    pub has_pending: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -43,7 +45,7 @@ impl From<&ltl::Value<RuntimeFunction>> for PropertyValue {
     fn from(value: &ltl::Value<RuntimeFunction>) -> Self {
         match value {
             ltl::Value::True => PropertyValue::True,
-            ltl::Value::False(violation) => {
+            ltl::Value::False(violation, _) => {
                 PropertyValue::False(violation.with_pretty_functions())
             }
             ltl::Value::Residual(_) => PropertyValue::Residual,
@@ -115,6 +117,7 @@ impl VerifierWorker {
                                         })
                                         .collect(),
                                     actions: result.actions,
+                                    has_pending: result.has_pending,
                                 },
                             ),
                         );
@@ -169,6 +172,7 @@ impl VerifierWorker {
         Ok(StepResult {
             properties: result.properties,
             actions,
+            has_pending: result.has_pending,
         })
     }
 }


### PR DESCRIPTION
When running without `--exit-on-violation`, any found violation would be cached for that property, and reported over and over again. This PR modifies the LTL evaluator to return an optional residual with any False value. The verifier then uses that to continue (if present), or mark the property as settled false. Only on continued evaluation with the residual the property can emit further violations.

Also, the ltl_equivalences tests are updated to run in continued stepping mode, which confirmed this bug and the fix.
