### PR TITLE
docs: getting started - edit a few lines for smoother phrasing

### DIFF
--- a/docs/manual/src/02-getting-started.md
+++ b/docs/manual/src/02-getting-started.md
@@ -137,6 +137,6 @@ Bombadil runs and produces results.
 
 
 ::: {.callout .callout-note}
-Bombadil doesn't yet produce a human-readable test report so while this test
-requires some `jq` trickery, stay tuned --- better UIs are on their way! 
+Bombadil doesn't yet produce a human-readable test report so while this process
+requires some `jq` trickery. Stay tuned --- better UIs are on their way! 
 :::


### PR DESCRIPTION
This section looks great! Just a few minor edits, in some cases additions (always aiming for the minimum viable amount) to match tenses, and/or make phrasing smoother. 

Re: the callout note at the end
-  for the purposes of these instructional docs I think maximum specificity is useful. I assumed "this" means "this test," so I edited it that way. 
- please feel free to revise if my edit is inaccurate or could be expressed better, e.g. maybe you meant something more like "this type of initial testing." 
- I'll leave it up to you to come up with whatever magic balance of brevity and specificity works best for you!