### PR TITLE
Fix stack overflow on `BundlerError`

### DIFF
--- a/lib/bombadil/src/specification/bundler/mod.rs
+++ b/lib/bombadil/src/specification/bundler/mod.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::specification::resolver::{ModuleKey, Resolver};
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, bail};
 use oxc::{
     allocator::{Allocator, TakeIn},
     ast::{NONE, ast},
@@ -36,11 +36,7 @@ pub enum BundlerError {
     },
 }
 
-impl From<BundlerError> for anyhow::Error {
-    fn from(value: BundlerError) -> Self {
-        anyhow!(value)
-    }
-}
+impl std::error::Error for BundlerError {}
 
 impl Display for BundlerError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Fixes https://github.com/antithesishq/bombadil/issues/124

On `bail!(BundlerError::SemanticErrors(errors))`, (which expands into an `anyhow!`) `anyhow!` was running `into()` on `BundlerError`, which had a `From` implementation that returned another `anyhow!`, recursing infinitely.