### PR TITLE
Stream trace entries to the inspector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ version = "0.1.0"
 dependencies = [
  "bombadil-browser-keys",
  "bombadil-schema",
+ "futures",
  "gloo-console",
  "gloo-net 0.6.0",
  "gloo-timers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -3776,14 +3776,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -3972,6 +3972,22 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -160,8 +161,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3769,6 +3772,18 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,7 +459,6 @@ dependencies = [
  "futures",
  "gloo-console",
  "gloo-net 0.6.0",
- "gloo-timers",
  "js-sys",
  "serde",
  "serde_json",

--- a/lib/bombadil-cli/Cargo.toml
+++ b/lib/bombadil-cli/Cargo.toml
@@ -12,7 +12,7 @@ bombadil = { path = "../bombadil" }
 bombadil-browser-keys = { path = "../bombadil-browser-keys" }
 bombadil-schema = { path = "../bombadil-schema" }
 anyhow = "1.0"
-axum = "0.8.8"
+axum = { version = "0.8.8", "features" = ["ws"] }
 clap = { version = "4.5.46", features = ["derive"] }
 env_logger = "0.11.8"
 include_dir = "0.7.4"

--- a/lib/bombadil-cli/src/inspect_server.rs
+++ b/lib/bombadil-cli/src/inspect_server.rs
@@ -32,6 +32,9 @@ pub async fn serve(
         trace_path
     };
 
+    let port_opt =
+        tokio::fs::read_to_string(trace_directory.join("WS_PORT")).await;
+
     let state = AppState { trace_directory };
 
     let app = Router::new()
@@ -43,7 +46,11 @@ pub async fn serve(
 
     let address = format!("127.0.0.1:{}", port);
     let listener = tokio::net::TcpListener::bind(&address).await?;
-    let url = format!("http://{}", address);
+    let mut url = format!("http://{}", address);
+
+    if let Ok(port) = port_opt {
+        url.push_str(&format!("?streaming-port={port}"));
+    }
 
     println!("Bombadil Inspect available at {}", url);
 

--- a/lib/bombadil-cli/src/main.rs
+++ b/lib/bombadil-cli/src/main.rs
@@ -74,6 +74,10 @@ struct TestSharedOptions {
         default_value = "local-network-access,local-network,loopback-network"
     )]
     chrome_grant_permissions: String,
+    /// The port on which to run the WS server streaming trace entries to the inspector.
+    /// If not specified, the OS will pick an available port.
+    #[arg(long)]
+    port_ws: Option<u16>,
 }
 
 #[derive(clap::Subcommand)]
@@ -283,8 +287,12 @@ async fn test(
     let output_path_clone = output_path.clone();
     let trace_tx_clone = trace_tx.clone();
     tokio::spawn(async move {
-        if let Err(e) =
-            test_server::serve(output_path_clone, None, trace_tx_clone).await
+        if let Err(e) = test_server::serve(
+            output_path_clone,
+            shared_options.port_ws,
+            trace_tx_clone,
+        )
+        .await
         {
             log::error!("test server failed: {e}");
         }

--- a/lib/bombadil-cli/src/main.rs
+++ b/lib/bombadil-cli/src/main.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use tempfile::TempDir;
-use tokio::sync::mpsc;
+use tokio::sync::broadcast;
 
 use bombadil::{
     browser::{
@@ -279,12 +279,12 @@ async fn test(
         }
     };
 
-
-    let (trace_tx, trace_rx) = mpsc::channel(16);
-    let output_path_cloned = output_path.clone();
+    let trace_tx = broadcast::Sender::new(16);
+    let output_path_clone = output_path.clone();
+    let trace_tx_clone = trace_tx.clone();
     tokio::spawn(async move {
         if let Err(e) =
-            test_server::serve(output_path_cloned, None, trace_rx).await
+            test_server::serve(output_path_clone, None, trace_tx_clone).await
         {
             log::error!("test server failed: {e}");
         }
@@ -304,7 +304,7 @@ async fn test(
         exit_on_violation: bool,
         test_start: Option<bombadil_schema::Time>,
         deadline: Option<SystemTime>,
-        trace_tx: mpsc::Sender<bombadil_schema::TraceEntry>,
+        trace_tx: broadcast::Sender<bombadil_schema::TraceEntry>,
         output_path: PathBuf,
         violations_count: u64,
     }
@@ -365,7 +365,7 @@ async fn test(
                 .write(state, last_action, snapshots, violations)
                 .await?;
 
-            let _ = self.trace_tx.send(trace_entry).await;
+            let _ = self.trace_tx.send(trace_entry);
 
             if self.violations_count > 0 && self.exit_on_violation {
                 return Ok(ControlFlow::Stop(TestResult {

--- a/lib/bombadil-cli/src/main.rs
+++ b/lib/bombadil-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod duration;
 mod inspect_server;
 mod render;
+mod test_server;
 
 use ::url::Url;
 use anyhow::Result;
@@ -11,6 +12,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use tempfile::TempDir;
+use tokio::sync::mpsc;
 
 use bombadil::{
     browser::{
@@ -277,6 +279,18 @@ async fn test(
         }
     };
 
+
+    let (trace_tx, trace_rx) = mpsc::channel(16);
+    let output_path_cloned = output_path.clone();
+    tokio::spawn(async move {
+        if let Err(e) =
+            test_server::serve(output_path_cloned, None, trace_rx).await
+        {
+            log::error!("test server failed: {e}");
+        }
+    });
+
+
     let runner = Runner::new(
         shared_options.origin.url,
         specification,
@@ -290,6 +304,7 @@ async fn test(
         exit_on_violation: bool,
         test_start: Option<bombadil_schema::Time>,
         deadline: Option<SystemTime>,
+        trace_tx: mpsc::Sender<bombadil_schema::TraceEntry>,
         output_path: PathBuf,
         violations_count: u64,
     }
@@ -391,6 +406,7 @@ async fn test(
         exit_on_violation: shared_options.exit_on_violation,
         test_start: None,
         deadline,
+        trace_tx,
         output_path: output_path.clone(),
         violations_count: 0,
     };

--- a/lib/bombadil-cli/src/main.rs
+++ b/lib/bombadil-cli/src/main.rs
@@ -360,9 +360,12 @@ async fn test(
                 );
             }
 
-            self.writer
+            let trace_entry = self
+                .writer
                 .write(state, last_action, snapshots, violations)
                 .await?;
+
+            let _ = self.trace_tx.send(trace_entry).await;
 
             if self.violations_count > 0 && self.exit_on_violation {
                 return Ok(ControlFlow::Stop(TestResult {

--- a/lib/bombadil-cli/src/main.rs
+++ b/lib/bombadil-cli/src/main.rs
@@ -298,7 +298,6 @@ async fn test(
         }
     });
 
-
     let runner = Runner::new(
         shared_options.origin.url,
         specification,

--- a/lib/bombadil-cli/src/test_server.rs
+++ b/lib/bombadil-cli/src/test_server.rs
@@ -59,7 +59,6 @@ pub async fn serve(
             // `send` returns Err when there are no active receivers
             // (eg when no ws clients). Ignore.
             let _ = trace_forward_tx.send(trace);
-            log::trace!("forwarded trace");
         }
     });
 

--- a/lib/bombadil-cli/src/test_server.rs
+++ b/lib/bombadil-cli/src/test_server.rs
@@ -4,9 +4,9 @@ use axum::{
     Router,
     extract::{
         State,
-        ws::{Message, Utf8Bytes, WebSocket, WebSocketUpgrade},
+        ws::{Message, WebSocket, WebSocketUpgrade},
     },
-    response::{IntoResponse, Response},
+    response::IntoResponse,
     routing::any,
 };
 

--- a/lib/bombadil-cli/src/test_server.rs
+++ b/lib/bombadil-cli/src/test_server.rs
@@ -10,18 +10,18 @@ use axum::{
 };
 use bombadil_schema::{Time, TraceEntry, WsTraceEntryMessage};
 use std::{io::Result, path::PathBuf};
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::broadcast;
 
 #[derive(Clone)]
 struct AppState {
     trace_directory: PathBuf,
-    trace_forward_tx: broadcast::Sender<TraceEntry>,
+    trace_tx: broadcast::Sender<TraceEntry>,
 }
 
 pub async fn serve(
     trace_path: PathBuf,
     port: Option<u16>,
-    mut trace_rx: mpsc::Receiver<TraceEntry>,
+    trace_tx: broadcast::Sender<TraceEntry>,
 ) -> Result<()> {
     log::debug!("starting ws server");
 
@@ -34,11 +34,9 @@ pub async fn serve(
         trace_path
     };
 
-    let trace_forward_tx = broadcast::Sender::new(64);
-
     let state = AppState {
         trace_directory,
-        trace_forward_tx,
+        trace_tx,
     };
 
     let address = format!("127.0.0.1:{}", port.unwrap_or(0));
@@ -53,18 +51,9 @@ pub async fn serve(
     )
     .await?;
 
-    let trace_forward_tx = state.trace_forward_tx.clone();
-    tokio::task::spawn(async move {
-        while let Some(trace) = trace_rx.recv().await {
-            // `send` returns Err when there are no active receivers
-            // (eg when no ws clients). Ignore.
-            let _ = trace_forward_tx.send(trace);
-        }
-    });
-
     let app = Router::new().route("/", any(ws_handler)).with_state(state);
 
-    log::info!("connect to the WS with wscat -c ws://{actual_address}");
+    log::debug!("ws running at ws://{actual_address}");
 
     axum::serve(listener, app).await?;
 
@@ -76,7 +65,7 @@ async fn ws_handler(
     State(state): State<AppState>,
 ) -> impl IntoResponse {
     // Subscribe before anything else so none are dropped.
-    let mut new_trace_forward_rx = state.trace_forward_tx.subscribe();
+    let mut new_trace_rx = state.trace_tx.subscribe();
 
     let existing = get_all_traces(state.trace_directory)
         .await
@@ -103,7 +92,7 @@ async fn ws_handler(
         }
 
         // Then stream new ones as they arrive.
-        while let Ok(new_trace) = new_trace_forward_rx.recv().await {
+        while let Ok(new_trace) = new_trace_rx.recv().await {
             // Filter out duplicate traces (in case one comes in while get_all_traces is running).
             if new_trace.timestamp <= last_existing_timestamp {
                 continue;

--- a/lib/bombadil-cli/src/test_server.rs
+++ b/lib/bombadil-cli/src/test_server.rs
@@ -1,5 +1,4 @@
-use std::{io::Result, path::PathBuf};
-
+/// This is a web server for `bombadil test` that streams trace entries for `bombadil inspect`. See https://github.com/antithesishq/bombadil/pull/141
 use axum::{
     Router,
     extract::{
@@ -9,8 +8,8 @@ use axum::{
     response::IntoResponse,
     routing::any,
 };
-
-use bombadil_schema::TraceEntry;
+use bombadil_schema::{Time, TraceEntry};
+use std::{io::Result, path::PathBuf};
 use tokio::sync::{broadcast, mpsc};
 
 #[derive(Clone)]
@@ -19,7 +18,6 @@ struct AppState {
     trace_forward_tx: broadcast::Sender<TraceEntry>,
 }
 
-// The test server is a websocket producer that sends out new trace entries.
 pub async fn serve(
     trace_path: PathBuf,
     port: Option<u16>,
@@ -36,7 +34,7 @@ pub async fn serve(
         trace_path
     };
 
-    let trace_forward_tx = broadcast::Sender::new(100);
+    let trace_forward_tx = broadcast::Sender::new(64);
 
     let state = AppState {
         trace_directory,
@@ -47,7 +45,6 @@ pub async fn serve(
     let listener = tokio::net::TcpListener::bind(&address).await?;
     let actual_port = listener.local_addr()?.port();
     let actual_address = listener.local_addr()?;
-    let url = format!("http://{}", actual_address);
 
     tokio::fs::create_dir_all(&state.trace_directory).await?;
     tokio::fs::write(
@@ -59,8 +56,8 @@ pub async fn serve(
     let trace_forward_tx = state.trace_forward_tx.clone();
     tokio::task::spawn(async move {
         while let Some(trace) = trace_rx.recv().await {
-            // send returns Err when there are no active receivers,
-            // which is expected when no WS clients are connected.
+            // `send` returns Err when there are no active receivers
+            // (eg when no ws clients). Ignore.
             let _ = trace_forward_tx.send(trace);
             log::trace!("forwarded trace");
         }

--- a/lib/bombadil-cli/src/test_server.rs
+++ b/lib/bombadil-cli/src/test_server.rs
@@ -85,18 +85,54 @@ async fn ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
+    // Subscribe before anything else so none are dropped.
     let mut new_trace_forward_rx = state.trace_forward_tx.subscribe();
-    ws.on_upgrade(|mut socket: WebSocket| async move {
+
+    let existing = get_all_traces(state.trace_directory)
+        .await
+        .unwrap_or_default();
+    let last_existing_timestamp = existing
+        .last()
+        .map(|e| e.timestamp)
+        .unwrap_or(Time::from_micros(0));
+
+    ws.on_upgrade(async move |mut socket: WebSocket| {
         log::debug!("ws client connected");
 
-        while let Ok(new_trace) = new_trace_forward_rx.recv().await {
-            let trace_json = serde_json::to_string(&new_trace).unwrap();
-            let msg = Message::Text(trace_json.into());
+        // Send all existing traces first.
+        let msg =
+            serde_json::to_string(&WsMessage::AllEntries(existing)).unwrap();
+        if socket.send(Message::Text(msg.into())).await.is_err() {
+            log::debug!(
+                "ws client disconnected before existing traces were sent"
+            );
+            return;
+        }
 
-            if socket.send(msg).await.is_err() {
+        // Then stream new ones as they arrive.
+        while let Ok(new_trace) = new_trace_forward_rx.recv().await {
+            // Filter out duplicate traces (in case one comes in while get_all_traces is running).
+            if new_trace.timestamp <= last_existing_timestamp {
+                continue;
+            }
+
+            let msg = serde_json::to_string(&WsMessage::Entry(new_trace))
+                .expect("Failed to serialize trace entry");
+            if socket.send(Message::Text(msg.into())).await.is_err() {
                 log::debug!("ws client disconnected");
                 return;
             }
         }
     })
+}
+
+async fn get_all_traces(
+    trace_directory: PathBuf,
+) -> anyhow::Result<Vec<TraceEntry>> {
+    let contents =
+        &tokio::fs::read(trace_directory.join("trace.jsonl")).await?;
+    String::from_utf8_lossy(contents)
+        .lines()
+        .map(|e| Ok(serde_json::from_str(e)?))
+        .collect()
 }

--- a/lib/bombadil-cli/src/test_server.rs
+++ b/lib/bombadil-cli/src/test_server.rs
@@ -1,0 +1,96 @@
+use std::{io::Result, path::PathBuf};
+
+use axum::{
+    Router,
+    extract::{
+        State,
+        ws::{Message, Utf8Bytes, WebSocket, WebSocketUpgrade},
+    },
+    response::{IntoResponse, Response},
+    routing::any,
+};
+
+use bombadil_schema::TraceEntry;
+use tokio::sync::{broadcast, mpsc};
+
+#[derive(Clone)]
+struct AppState {
+    trace_directory: PathBuf,
+    trace_forward_tx: broadcast::Sender<TraceEntry>,
+}
+
+// The test server is a websocket producer that sends out new trace entries.
+pub async fn serve(
+    trace_path: PathBuf,
+    port: Option<u16>,
+    mut trace_rx: mpsc::Receiver<TraceEntry>,
+) -> Result<()> {
+    log::debug!("starting ws server");
+
+    let trace_directory = if trace_path.is_file() {
+        trace_path
+            .parent()
+            .expect("trace path has no parent")
+            .to_path_buf()
+    } else {
+        trace_path
+    };
+
+    let trace_forward_tx = broadcast::Sender::new(100);
+
+    let state = AppState {
+        trace_directory,
+        trace_forward_tx,
+    };
+
+    let address = format!("127.0.0.1:{}", port.unwrap_or(0));
+    let listener = tokio::net::TcpListener::bind(&address).await?;
+    let actual_port = listener.local_addr()?.port();
+    let actual_address = listener.local_addr()?;
+    let url = format!("http://{}", actual_address);
+
+    tokio::fs::create_dir_all(&state.trace_directory).await?;
+    tokio::fs::write(
+        state.trace_directory.join("WS_PORT"),
+        actual_port.to_string(),
+    )
+    .await?;
+
+    let trace_forward_tx = state.trace_forward_tx.clone();
+    tokio::task::spawn(async move {
+        while let Some(trace) = trace_rx.recv().await {
+            // send returns Err when there are no active receivers,
+            // which is expected when no WS clients are connected.
+            let _ = trace_forward_tx.send(trace);
+            log::trace!("forwarded trace");
+        }
+    });
+
+    let app = Router::new().route("/", any(ws_handler)).with_state(state);
+
+    log::info!("connect to the WS with wscat -c ws://{actual_address}");
+
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    let mut new_trace_forward_rx = state.trace_forward_tx.subscribe();
+    ws.on_upgrade(|mut socket: WebSocket| async move {
+        log::debug!("ws client connected");
+
+        while let Ok(new_trace) = new_trace_forward_rx.recv().await {
+            let trace_json = serde_json::to_string(&new_trace).unwrap();
+            let msg = Message::Text(trace_json.into());
+
+            if socket.send(msg).await.is_err() {
+                log::debug!("ws client disconnected");
+                return;
+            }
+        }
+    })
+}

--- a/lib/bombadil-cli/src/test_server.rs
+++ b/lib/bombadil-cli/src/test_server.rs
@@ -90,7 +90,8 @@ async fn ws_handler(
         log::debug!("ws client connected");
 
         // Send all existing traces first.
-        let existing = existing.into_iter().map(rewrite_screenshot_path).collect();
+        let existing =
+            existing.into_iter().map(rewrite_screenshot_path).collect();
         let msg =
             serde_json::to_string(&WsTraceEntryMessage::AllEntries(existing))
                 .unwrap();

--- a/lib/bombadil-cli/src/test_server.rs
+++ b/lib/bombadil-cli/src/test_server.rs
@@ -75,6 +75,15 @@ pub async fn serve(
     Ok(())
 }
 
+#[derive(serde::Serialize)]
+#[serde(tag = "type", content = "data")]
+enum WsMessage {
+    #[serde(rename = "entry")]
+    Entry(TraceEntry),
+    #[serde(rename = "allEntries")]
+    AllEntries(Vec<TraceEntry>),
+}
+
 async fn ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<AppState>,

--- a/lib/bombadil-cli/src/test_server.rs
+++ b/lib/bombadil-cli/src/test_server.rs
@@ -8,7 +8,7 @@ use axum::{
     response::IntoResponse,
     routing::any,
 };
-use bombadil_schema::{Time, TraceEntry};
+use bombadil_schema::{Time, TraceEntry, WsTraceEntryMessage};
 use std::{io::Result, path::PathBuf};
 use tokio::sync::{broadcast, mpsc};
 
@@ -71,15 +71,6 @@ pub async fn serve(
     Ok(())
 }
 
-#[derive(serde::Serialize)]
-#[serde(tag = "type", content = "data")]
-enum WsMessage {
-    #[serde(rename = "entry")]
-    Entry(TraceEntry),
-    #[serde(rename = "allEntries")]
-    AllEntries(Vec<TraceEntry>),
-}
-
 async fn ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<AppState>,
@@ -99,8 +90,10 @@ async fn ws_handler(
         log::debug!("ws client connected");
 
         // Send all existing traces first.
+        let existing = existing.into_iter().map(rewrite_screenshot_path).collect();
         let msg =
-            serde_json::to_string(&WsMessage::AllEntries(existing)).unwrap();
+            serde_json::to_string(&WsTraceEntryMessage::AllEntries(existing))
+                .unwrap();
         if socket.send(Message::Text(msg.into())).await.is_err() {
             log::debug!(
                 "ws client disconnected before existing traces were sent"
@@ -115,14 +108,26 @@ async fn ws_handler(
                 continue;
             }
 
-            let msg = serde_json::to_string(&WsMessage::Entry(new_trace))
-                .expect("Failed to serialize trace entry");
+            let new_trace = rewrite_screenshot_path(new_trace);
+            let msg =
+                serde_json::to_string(&WsTraceEntryMessage::Entry(new_trace))
+                    .expect("Failed to serialize trace entry");
             if socket.send(Message::Text(msg.into())).await.is_err() {
                 log::debug!("ws client disconnected");
                 return;
             }
         }
     })
+}
+
+fn rewrite_screenshot_path(mut entry: TraceEntry) -> TraceEntry {
+    let filename = std::path::Path::new(&entry.screenshot)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("")
+        .to_string();
+    entry.screenshot = format!("/api/screenshots/{}", filename);
+    entry
 }
 
 async fn get_all_traces(

--- a/lib/bombadil-inspect/Cargo.toml
+++ b/lib/bombadil-inspect/Cargo.toml
@@ -18,12 +18,13 @@ web-sys = { version = "0.3", features = [
     "Location",
     "ResizeObserver",
     "ResizeObserverEntry",
+    "ScrollIntoViewOptions",
+    "ScrollLogicalPosition",
     "UrlSearchParams",
     "Window",
 ] }
 gloo-net = { version = "0.6", features = ["websocket"] }
 gloo-console = "0.3"
-gloo-timers = "0.3"
 bombadil-browser-keys = { path = "../bombadil-browser-keys" }
 bombadil-schema = { path = "../bombadil-schema" }
 serde = { version = "1.0", features = ["derive"] }

--- a/lib/bombadil-inspect/Cargo.toml
+++ b/lib/bombadil-inspect/Cargo.toml
@@ -15,17 +15,20 @@ web-sys = { version = "0.3", features = [
     "EventTarget",
     "HtmlElement",
     "HtmlImageElement",
+    "Location",
     "ResizeObserver",
     "ResizeObserverEntry",
+    "UrlSearchParams",
     "Window",
 ] }
-gloo-net = "0.6"
+gloo-net = { version = "0.6", features = ["websocket"] }
 gloo-console = "0.3"
 gloo-timers = "0.3"
 bombadil-browser-keys = { path = "../bombadil-browser-keys" }
 bombadil-schema = { path = "../bombadil-schema" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+futures = "0.3.32"
 
 [lib]
 crate-type = ["cdylib"]

--- a/lib/bombadil-inspect/src/actions.css
+++ b/lib/bombadil-inspect/src/actions.css
@@ -120,3 +120,12 @@
     vertical-align: top;
     text-align: right;
 }
+
+.actions .following-indicator {
+    position: absolute;
+    bottom: -1px;
+    left: 50%;
+    transform: translateX(-50%);
+    pointer-events: none;
+    /*background-color: var(--color-bg-muted);*/
+}

--- a/lib/bombadil-inspect/src/actions.css
+++ b/lib/bombadil-inspect/src/actions.css
@@ -121,11 +121,12 @@
     text-align: right;
 }
 
-.actions .following-indicator {
+.actions .follow-list {
     position: absolute;
     bottom: -1px;
     left: 50%;
     transform: translateX(-50%);
-    pointer-events: none;
-    /*background-color: var(--color-bg-muted);*/
+    background-color: var(--color-bg-muted);
+    border: 1px solid var(--color-border);
+    padding: 0.5em 1em;
 }

--- a/lib/bombadil-inspect/src/actions.rs
+++ b/lib/bombadil-inspect/src/actions.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use bombadil_browser_keys::key_name;
@@ -5,7 +6,6 @@ use bombadil_schema::{Point, Time, TraceEntry};
 use yew::component;
 use yew::prelude::*;
 
-use crate::container_size::use_container_size;
 use crate::list_autoscroll::use_list_autoscroll;
 use crate::time::Duration;
 
@@ -14,13 +14,18 @@ pub struct ActionsListProps {
     pub trace: Rc<[TraceEntry]>,
     pub selected_index: usize,
     pub on_select: Callback<usize>,
+    pub is_following: Rc<RefCell<bool>>,
 }
 
 #[component]
 pub fn ActionsList(props: &ActionsListProps) -> Html {
     let test_start =
         props.trace.first().expect("no first trace entry").timestamp;
-    let list_ref = use_list_autoscroll(props.selected_index);
+    let list_ref = use_list_autoscroll(
+        props.selected_index,
+        props.is_following.clone(),
+        props.on_select.clone(),
+    );
 
     html!(
         <ol ref={list_ref}>
@@ -51,8 +56,6 @@ struct HistoryEntryProps {
 
 #[component]
 fn ActionEntry(props: &HistoryEntryProps) -> Html {
-    let (container_ref, container_size) = use_container_size();
-
     let (action_header, details): (Html, Option<Vec<(&str, String)>>) =
         match &props.entry.action {
             Some(action) => match action {
@@ -188,12 +191,12 @@ fn ActionEntry(props: &HistoryEntryProps) -> Html {
 
     html! {
         <li class={li_class}>
-            <button onclick={on_click} ref={container_ref}>
+            <button onclick={on_click}>
                 {
-                    if props.is_selected && let Some((width, height)) = container_size {
+                    if props.is_selected {
                         html!(
                             <svg class="background" xmlns="http://www.w3.org/2000/svg">
-                                <rect width={width.to_string()} height={height.to_string()} fill="url(#dither)" />
+                                <rect width="100%" height="100%" fill="url(#dither)" />
                             </svg>
                         )
                     } else {

--- a/lib/bombadil-inspect/src/actions.rs
+++ b/lib/bombadil-inspect/src/actions.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::rc::Rc;
 
 use bombadil_browser_keys::key_name;

--- a/lib/bombadil-inspect/src/actions.rs
+++ b/lib/bombadil-inspect/src/actions.rs
@@ -11,7 +11,7 @@ use crate::time::Duration;
 
 #[derive(PartialEq, Properties)]
 pub struct ActionsListProps {
-    pub trace: Rc<[TraceEntry]>,
+    pub trace: Rc<[Rc<TraceEntry>]>,
     pub selected_index: usize,
     pub on_select: Callback<usize>,
     pub is_following: Rc<RefCell<bool>>,
@@ -33,7 +33,7 @@ pub fn ActionsList(props: &ActionsListProps) -> Html {
             props.trace.iter().enumerate().map(|(i, entry)| {
                 html!(
                     <ActionEntry
-                        entry={Rc::new(entry.clone())}
+                        entry={entry.clone()}
                         is_selected={i == props.selected_index}
                             test_start={test_start}
                             index={i}

--- a/lib/bombadil-inspect/src/actions.rs
+++ b/lib/bombadil-inspect/src/actions.rs
@@ -14,7 +14,7 @@ pub struct ActionsListProps {
     pub trace: Rc<[Rc<TraceEntry>]>,
     pub selected_index: usize,
     pub on_select: Callback<usize>,
-    pub is_following: Rc<RefCell<bool>>,
+    pub is_following: UseStateHandle<bool>,
 }
 
 #[component]

--- a/lib/bombadil-inspect/src/layout.css
+++ b/lib/bombadil-inspect/src/layout.css
@@ -60,6 +60,7 @@ header.pane h1 {
     grid-row: 2 / 4;
     grid-column: 1;
     min-width: 28ch;
+    position: relative;
 }
 
 .pane.state-screenshot.before {

--- a/lib/bombadil-inspect/src/lib.rs
+++ b/lib/bombadil-inspect/src/lib.rs
@@ -33,6 +33,28 @@ fn app() -> Html {
     let search = web_sys::window().unwrap().location().search().unwrap();
     let params = web_sys::UrlSearchParams::new_with_str(&search).unwrap();
 
+    async fn load_trace_file(
+        trace: UseStateHandle<Option<Rc<[Rc<TraceEntry>]>>>,
+    ) {
+        let response = match Request::get("/api/trace").send().await {
+            Ok(r) => r,
+            Err(e) => {
+                return error!("Failed to fetch:", e.to_string());
+            }
+        };
+        match response.json::<Vec<TraceEntry>>().await {
+            Ok(entries) => {
+                log!("Loaded trace entries:", entries.len());
+                let entries: Vec<_> =
+                    entries.into_iter().map(Rc::new).collect();
+                trace.set(Some(Rc::from(entries)));
+            }
+            Err(e) => {
+                error!("Failed to parse response:", e.to_string())
+            }
+        }
+    }
+
     {
         let trace = trace.clone();
         use_effect_with((), move |_| {
@@ -65,28 +87,14 @@ fn app() -> Html {
                             Err(e) => log!(format!("{e}")),
                         }
                     }
+
+                    log!(
+                        "WS disconnected - falling back to loading the trace file"
+                    );
+                    spawn_local(async { load_trace_file(trace).await });
                 })
             } else {
-                spawn_local(async move {
-                    let response = match Request::get("/api/trace").send().await
-                    {
-                        Ok(r) => r,
-                        Err(e) => {
-                            return error!("Failed to fetch:", e.to_string());
-                        }
-                    };
-                    match response.json::<Vec<TraceEntry>>().await {
-                        Ok(entries) => {
-                            log!("Loaded trace entries:", entries.len());
-                            let entries: Vec<_> =
-                                entries.into_iter().map(Rc::new).collect();
-                            trace.set(Some(Rc::from(entries)));
-                        }
-                        Err(e) => {
-                            error!("Failed to parse response:", e.to_string())
-                        }
-                    }
-                });
+                spawn_local(async { load_trace_file(trace).await });
             }
             || ()
         });

--- a/lib/bombadil-inspect/src/lib.rs
+++ b/lib/bombadil-inspect/src/lib.rs
@@ -57,7 +57,8 @@ fn app() -> Html {
                                 trace.set(Some(Rc::from(entries)));
                             }
                             Ok(WsTraceEntryMessage::AllEntries(all)) => {
-                                let entries: Vec<_> = all.into_iter().map(Rc::new).collect();
+                                let entries: Vec<_> =
+                                    all.into_iter().map(Rc::new).collect();
                                 trace.set(Some(Rc::from(entries)))
                             }
                             Err(e) => log!(format!("{e}")),
@@ -76,7 +77,8 @@ fn app() -> Html {
                     match response.json::<Vec<TraceEntry>>().await {
                         Ok(entries) => {
                             log!("Loaded trace entries:", entries.len());
-                            let entries: Vec<_> = entries.into_iter().map(Rc::new).collect();
+                            let entries: Vec<_> =
+                                entries.into_iter().map(Rc::new).collect();
                             trace.set(Some(Rc::from(entries)));
                         }
                         Err(e) => {
@@ -114,10 +116,8 @@ fn app() -> Html {
         .as_ref()
         .and_then(|t| t.get(effective_index.saturating_sub(1)))
         .cloned();
-    let after_entry = trace
-        .as_ref()
-        .and_then(|t| t.get(effective_index))
-        .cloned();
+    let after_entry =
+        trace.as_ref().and_then(|t| t.get(effective_index)).cloned();
     let action = after_entry
         .as_ref()
         .and_then(|e| e.action.clone())

--- a/lib/bombadil-inspect/src/lib.rs
+++ b/lib/bombadil-inspect/src/lib.rs
@@ -26,7 +26,7 @@ mod timeline;
 #[function_component(App)]
 fn app() -> Html {
     let selected_index = use_state_eq(|| 1usize);
-    let trace = use_state(|| None::<Rc<[TraceEntry]>>);
+    let trace = use_state(|| None::<Rc<[Rc<TraceEntry>]>>);
     let is_following_list = use_mut_ref(|| true);
 
     let search = web_sys::window().unwrap().location().search().unwrap();
@@ -53,11 +53,12 @@ fn app() -> Html {
                                     .as_ref()
                                     .map(|t| t.to_vec())
                                     .unwrap_or_default();
-                                entries.push(entry);
+                                entries.push(Rc::new(entry));
                                 trace.set(Some(Rc::from(entries)));
                             }
                             Ok(WsTraceEntryMessage::AllEntries(all)) => {
-                                trace.set(Some(Rc::from(all)))
+                                let entries: Vec<_> = all.into_iter().map(Rc::new).collect();
+                                trace.set(Some(Rc::from(entries)))
                             }
                             Err(e) => log!(format!("{e}")),
                         }
@@ -75,6 +76,7 @@ fn app() -> Html {
                     match response.json::<Vec<TraceEntry>>().await {
                         Ok(entries) => {
                             log!("Loaded trace entries:", entries.len());
+                            let entries: Vec<_> = entries.into_iter().map(Rc::new).collect();
                             trace.set(Some(Rc::from(entries)));
                         }
                         Err(e) => {
@@ -111,11 +113,11 @@ fn app() -> Html {
     let before_entry = trace
         .as_ref()
         .and_then(|t| t.get(effective_index.saturating_sub(1)))
-        .map(|e| Rc::new(e.clone()));
+        .cloned();
     let after_entry = trace
         .as_ref()
         .and_then(|t| t.get(effective_index))
-        .map(|e| Rc::new(e.clone()));
+        .cloned();
     let action = after_entry
         .as_ref()
         .and_then(|e| e.action.clone())

--- a/lib/bombadil-inspect/src/lib.rs
+++ b/lib/bombadil-inspect/src/lib.rs
@@ -110,6 +110,7 @@ fn app() -> Html {
         })
     };
 
+    // TODO: this should be part of test metadata
     let test_start =
         trace.as_ref().and_then(|t| t.first()).map(|e| e.timestamp);
     let before_entry = trace

--- a/lib/bombadil-inspect/src/lib.rs
+++ b/lib/bombadil-inspect/src/lib.rs
@@ -1,10 +1,10 @@
 use std::rc::Rc;
 
 use bombadil_schema::{TraceEntry, WsTraceEntryMessage};
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 use gloo_console::{error, log};
 use gloo_net::http::Request;
-use gloo_net::websocket::{Message, futures::WebSocket};
+use gloo_net::websocket::futures::WebSocket;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
@@ -27,6 +27,7 @@ mod timeline;
 fn app() -> Html {
     let selected_index = use_state_eq(|| 1usize);
     let trace = use_state(|| None::<Rc<[TraceEntry]>>);
+    let is_following_list = use_mut_ref(|| true);
 
     let search = web_sys::window().unwrap().location().search().unwrap();
     let params = web_sys::UrlSearchParams::new_with_str(&search).unwrap();
@@ -86,6 +87,40 @@ fn app() -> Html {
         });
     }
 
+    // When following, derive the selected index from the trace length so that
+    // a single `trace.set()` in the WS handler is enough — no second state
+    // update, no double-render flicker.
+    let trace_len = trace.as_ref().map(|t| t.len()).unwrap_or(0);
+    let effective_index = if *is_following_list.borrow() {
+        trace_len.saturating_sub(1)
+    } else {
+        *selected_index
+    };
+
+    let on_select = {
+        let selected_index = selected_index.clone();
+        let is_following_list = is_following_list.clone();
+        Callback::from(move |index: usize| {
+            selected_index.set(index);
+            *is_following_list.borrow_mut() = index == trace_len - 1;
+        })
+    };
+
+    let test_start =
+        trace.as_ref().and_then(|t| t.first()).map(|e| e.timestamp);
+    let before_entry = trace
+        .as_ref()
+        .and_then(|t| t.get(effective_index.saturating_sub(1)))
+        .map(|e| Rc::new(e.clone()));
+    let after_entry = trace
+        .as_ref()
+        .and_then(|t| t.get(effective_index))
+        .map(|e| Rc::new(e.clone()));
+    let action = after_entry
+        .as_ref()
+        .and_then(|e| e.action.clone())
+        .map(Rc::new);
+
     html! {
         <main class="grid">
 
@@ -110,63 +145,55 @@ fn app() -> Html {
                 <div class="content">
                 {
                     if let Some(trace) = trace.as_ref() && !trace.is_empty() {
-                        let selected_index = selected_index.clone();
                         html!(
                             <ActionsList
                                 trace={trace.clone()}
-                                selected_index={*selected_index}
-                                on_select={Callback::from(move |index| { selected_index.set(index) })}
+                                selected_index={effective_index}
+                                on_select={on_select.clone()}
+                                is_following={is_following_list.clone()}
                                 />
                             )
                     } else { Html::default() }
                 }
                 </div>
+                {if *is_following_list.borrow() {
+                    html!(<p class="following-indicator">{"FOLLOWING"}</p>)
+                } else { Html::default() }}
             </div>
 
             <div class="pane state-screenshot before">
                 <h2>{"State before"}</h2>
-                {if let Some(ref trace) = *trace && let Some(entry) = trace.get(selected_index.saturating_sub(1)) {
-                    let action = trace.get(*selected_index).and_then(|e| e.action.clone()).map(Rc::new);
-                    html!(<Screenshot entry={Rc::new(entry.clone())} action={action} />)
+                {if let Some(ref entry) = before_entry {
+                    html!(<Screenshot entry={entry.clone()} action={action.clone()} />)
                 } else {Html::default()}}
             </div>
 
             <div class="pane state-screenshot after">
                 <h2>{"State after"}</h2>
-                {if let Some(ref trace) = *trace && let Some(entry) = trace.get(*selected_index) {
-                    html!(<Screenshot entry={Rc::new(entry.clone())} />)
+                {if let Some(ref entry) = after_entry {
+                    html!(<Screenshot entry={entry.clone()} />)
                 } else {Html::default()}}
             </div>
 
             <div class="pane state-details before">
                 <div class="content">
-                    {if let Some(ref trace) = *trace && let Some(entry) = trace.get(selected_index.saturating_sub(1)) {
-                        // TODO: this should be part of test metadata
-                        let test_start = trace.first().expect("no first trace entry").timestamp;
-                        html!(<StateDetails entry={Rc::new(entry.clone())} test_start={test_start} />)
+                    {if let (Some(entry), Some(test_start)) = (&before_entry, test_start) {
+                        html!(<StateDetails entry={entry.clone()} {test_start} />)
                     } else { Html::default() }}
                 </div>
             </div>
 
             <div class="pane state-details after">
                 <div class="content">
-                    {if let Some(ref trace) = *trace && let Some(entry) = trace.get(*selected_index) {
-                        // TODO: this should be part of test metadata
-                        let test_start = trace.first().expect("no first trace entry").timestamp;
-                        html!(<StateDetails entry={Rc::new(entry.clone())} test_start={test_start} />)
+                    {if let (Some(entry), Some(test_start)) = (&after_entry, test_start) {
+                        html!(<StateDetails entry={entry.clone()} {test_start} />)
                     } else {Html::default()}}
                 </div>
             </div>
 
             <footer class="pane">
-                {if let Some(ref trace) = *trace {
-                    // TODO: this should be part of test metadata
-                    let test_start = trace.first().expect("no first trace entry").timestamp;
-                    let on_select = {
-                        let selected_index = selected_index.clone();
-                        Callback::from(move |index| selected_index.set(index))
-                    };
-                    html!(<Timeline entries={trace.clone()} test_start={test_start} selected_index={*selected_index} on_select={on_select} />)
+                {if let (Some(trace), Some(test_start)) = (trace.as_ref(), test_start) {
+                    html!(<Timeline entries={Rc::clone(trace)} {test_start} selected_index={effective_index} on_select={on_select.clone()} />)
                 } else {Html::default()}}
             </footer>
         </main>

--- a/lib/bombadil-inspect/src/lib.rs
+++ b/lib/bombadil-inspect/src/lib.rs
@@ -41,69 +41,43 @@ fn app() -> Html {
 
                 spawn_local(async move {
                     while let Some(msg) = read.next().await {
-                        match msg {
-                            Ok(msg) => match msg {
-                                gloo_net::websocket::Message::Text(
-                                    msg_text,
-                                ) => {
-                                    match serde_json::from_str::<
-                                        WsTraceEntryMessage,
-                                    >(
-                                        &msg_text
-                                    ) {
-                                        Ok(trace_entry_msg) => {
-                                            match trace_entry_msg {
-                                                WsTraceEntryMessage::Entry(
-                                                    entry,
-                                                ) => {
-                                                    let mut entries = trace.as_ref().map(|t| t.to_vec()).unwrap_or_default();
-                                                    entries.push(entry);
-                                                    trace.set(Some(Rc::from(entries)));
-                                                }
-                                                 WsTraceEntryMessage::AllEntries(all_entries) => {
-                                                     trace.set(Some(Rc::from(all_entries)))
-                                                 }
-                                            }
-                                        }
-                                        Err(trace_entry_err) => {
-                                            log!("{trace_entry_err}")
-                                        }
-                                    }
-
-                                    log!(format!("1. {:?}", msg_text));
-                                }
-                                gloo_net::websocket::Message::Bytes(_) => {
-                                    log!("Hm. Unexpected bytes recv: {bytes}")
-                                }
-                            },
-                            Err(e) => {
-                                log!(format!("{e}"));
+                        let Ok(gloo_net::websocket::Message::Text(text)) = msg
+                        else {
+                            continue;
+                        };
+                        match serde_json::from_str::<WsTraceEntryMessage>(&text)
+                        {
+                            Ok(WsTraceEntryMessage::Entry(entry)) => {
+                                let mut entries = trace
+                                    .as_ref()
+                                    .map(|t| t.to_vec())
+                                    .unwrap_or_default();
+                                entries.push(entry);
+                                trace.set(Some(Rc::from(entries)));
                             }
+                            Ok(WsTraceEntryMessage::AllEntries(all)) => {
+                                trace.set(Some(Rc::from(all)))
+                            }
+                            Err(e) => log!(format!("{e}")),
                         }
                     }
                 })
             } else {
                 spawn_local(async move {
-                    match Request::get("/api/trace").send().await {
-                        Ok(response) => {
-                            match response.json::<Vec<TraceEntry>>().await {
-                                Ok(entries) => {
-                                    log!(
-                                        "Loaded trace entries:",
-                                        entries.len()
-                                    );
-                                    trace.set(Some(Rc::from(entries)));
-                                }
-                                Err(error) => {
-                                    error!(
-                                        "Failed to parse response: ",
-                                        error.to_string()
-                                    )
-                                }
-                            }
+                    let response = match Request::get("/api/trace").send().await
+                    {
+                        Ok(r) => r,
+                        Err(e) => {
+                            return error!("Failed to fetch:", e.to_string());
                         }
-                        Err(error) => {
-                            error!("Failed to fetch:", error.to_string())
+                    };
+                    match response.json::<Vec<TraceEntry>>().await {
+                        Ok(entries) => {
+                            log!("Loaded trace entries:", entries.len());
+                            trace.set(Some(Rc::from(entries)));
+                        }
+                        Err(e) => {
+                            error!("Failed to parse response:", e.to_string())
                         }
                     }
                 });

--- a/lib/bombadil-inspect/src/lib.rs
+++ b/lib/bombadil-inspect/src/lib.rs
@@ -27,7 +27,8 @@ mod timeline;
 fn app() -> Html {
     let selected_index = use_state_eq(|| 1usize);
     let trace = use_state(|| None::<Rc<[Rc<TraceEntry>]>>);
-    let is_following_list = use_mut_ref(|| true);
+
+    let is_following_list = use_state(|| true);
 
     let search = web_sys::window().unwrap().location().search().unwrap();
     let params = web_sys::UrlSearchParams::new_with_str(&search).unwrap();
@@ -95,7 +96,8 @@ fn app() -> Html {
     // a single `trace.set()` in the WS handler is enough — no second state
     // update, no double-render flicker.
     let trace_len = trace.as_ref().map(|t| t.len()).unwrap_or(0);
-    let effective_index = if *is_following_list.borrow() {
+
+    let effective_index = if *is_following_list {
         trace_len.saturating_sub(1)
     } else {
         *selected_index
@@ -106,7 +108,8 @@ fn app() -> Html {
         let is_following_list = is_following_list.clone();
         Callback::from(move |index: usize| {
             selected_index.set(index);
-            *is_following_list.borrow_mut() = index == trace_len - 1;
+
+            is_following_list.set(index == trace_len - 1);
         })
     };
 
@@ -159,8 +162,10 @@ fn app() -> Html {
                     } else { Html::default() }
                 }
                 </div>
-                {if *is_following_list.borrow() {
-                    html!(<p class="following-indicator">{"FOLLOWING"}</p>)
+                {if !*is_following_list {
+                    let ifl = is_following_list.clone();
+                    // TODO: Figure out why all the styles are overridden when using a button :/
+                    html!(<p onclick={Callback::from(move |_| ifl.set(true))} class="follow-list">{"↓ FOLLOW LIST ↓"}</p>)
                 } else { Html::default() }}
             </div>
 

--- a/lib/bombadil-inspect/src/lib.rs
+++ b/lib/bombadil-inspect/src/lib.rs
@@ -1,8 +1,10 @@
 use std::rc::Rc;
 
-use bombadil_schema::TraceEntry;
+use bombadil_schema::{TraceEntry, WsTraceEntryMessage};
+use futures::{SinkExt, StreamExt};
 use gloo_console::{error, log};
 use gloo_net::http::Request;
+use gloo_net::websocket::{Message, futures::WebSocket};
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
@@ -25,28 +27,87 @@ mod timeline;
 fn app() -> Html {
     let selected_index = use_state_eq(|| 1usize);
     let trace = use_state(|| None::<Rc<[TraceEntry]>>);
+
+    let search = web_sys::window().unwrap().location().search().unwrap();
+    let params = web_sys::UrlSearchParams::new_with_str(&search).unwrap();
+
     {
         let trace = trace.clone();
         use_effect_with((), move |_| {
-            spawn_local(async move {
-                match Request::get("/api/trace").send().await {
-                    Ok(response) => {
-                        match response.json::<Vec<TraceEntry>>().await {
-                            Ok(entries) => {
-                                log!("Loaded trace entries:", entries.len());
-                                trace.set(Some(Rc::from(entries)));
-                            }
-                            Err(error) => {
-                                error!(
-                                    "Failed to parse response: ",
-                                    error.to_string()
-                                )
+            if let Some(port) = params.get("streaming-port") {
+                let ws = WebSocket::open(&format!("ws://127.0.0.1:{port}/"))
+                    .unwrap();
+                let (_write, mut read) = ws.split();
+
+                spawn_local(async move {
+                    while let Some(msg) = read.next().await {
+                        match msg {
+                            Ok(msg) => match msg {
+                                gloo_net::websocket::Message::Text(
+                                    msg_text,
+                                ) => {
+                                    match serde_json::from_str::<
+                                        WsTraceEntryMessage,
+                                    >(
+                                        &msg_text
+                                    ) {
+                                        Ok(trace_entry_msg) => {
+                                            match trace_entry_msg {
+                                                WsTraceEntryMessage::Entry(
+                                                    entry,
+                                                ) => {
+                                                    let mut entries = trace.as_ref().map(|t| t.to_vec()).unwrap_or_default();
+                                                    entries.push(entry);
+                                                    trace.set(Some(Rc::from(entries)));
+                                                }
+                                                 WsTraceEntryMessage::AllEntries(all_entries) => {
+                                                     trace.set(Some(Rc::from(all_entries)))
+                                                 }
+                                            }
+                                        }
+                                        Err(trace_entry_err) => {
+                                            log!("{trace_entry_err}")
+                                        }
+                                    }
+
+                                    log!(format!("1. {:?}", msg_text));
+                                }
+                                gloo_net::websocket::Message::Bytes(_) => {
+                                    log!("Hm. Unexpected bytes recv: {bytes}")
+                                }
+                            },
+                            Err(e) => {
+                                log!(format!("{e}"));
                             }
                         }
                     }
-                    Err(error) => error!("Failed to fetch:", error.to_string()),
-                }
-            });
+                })
+            } else {
+                spawn_local(async move {
+                    match Request::get("/api/trace").send().await {
+                        Ok(response) => {
+                            match response.json::<Vec<TraceEntry>>().await {
+                                Ok(entries) => {
+                                    log!(
+                                        "Loaded trace entries:",
+                                        entries.len()
+                                    );
+                                    trace.set(Some(Rc::from(entries)));
+                                }
+                                Err(error) => {
+                                    error!(
+                                        "Failed to parse response: ",
+                                        error.to_string()
+                                    )
+                                }
+                            }
+                        }
+                        Err(error) => {
+                            error!("Failed to fetch:", error.to_string())
+                        }
+                    }
+                });
+            }
             || ()
         });
     }

--- a/lib/bombadil-inspect/src/list_autoscroll.rs
+++ b/lib/bombadil-inspect/src/list_autoscroll.rs
@@ -1,104 +1,66 @@
-use gloo_timers::callback::Timeout;
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use wasm_bindgen::JsCast;
-use wasm_bindgen::JsValue;
 use yew::prelude::*;
 
 #[hook]
-pub fn use_list_autoscroll(selected_index: usize) -> NodeRef {
+pub fn use_list_autoscroll(
+    selected_index: usize,
+    is_following: Rc<RefCell<bool>>,
+    on_select: Callback<usize>,
+) -> NodeRef {
     let list_ref = use_node_ref();
+    let current_index = use_mut_ref(|| selected_index);
+    *current_index.borrow_mut() = selected_index;
 
+    // Scroll listener: update is_following based on scroll position.
+    // When transitioning from following to not-following, snapshot the
+    // current selected_index so the view stays put.
+    {
+        let list_ref = list_ref.clone();
+        use_effect_with((), move |_| {
+            let container = list_ref
+                .cast::<web_sys::HtmlElement>()
+                .and_then(|list| list.parent_element())
+                .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok());
+
+            let Some(container) = container else { return };
+
+            let scroll_container = container.clone();
+            let closure = wasm_bindgen::closure::Closure::<dyn Fn()>::wrap(
+                Box::new(move || {
+                    let at_bottom = scroll_container.scroll_top() as f64
+                        + scroll_container.client_height() as f64
+                        >= scroll_container.scroll_height() as f64 - 5.0;
+                    let was_following = *is_following.borrow();
+                    *is_following.borrow_mut() = at_bottom;
+                    if was_following && !at_bottom {
+                        on_select.emit(*current_index.borrow());
+                    }
+                }),
+            );
+
+            let _ = container.add_event_listener_with_callback(
+                "scroll",
+                closure.as_ref().unchecked_ref(),
+            );
+            closure.forget();
+        });
+    }
+
+    // Scroll selected item into view.
     {
         let list_ref = list_ref.clone();
         use_effect_with(selected_index, move |_| {
-            let timeout = Timeout::new(0, move || {
-                if let Some(list) = list_ref.cast::<web_sys::HtmlElement>()
-                    && let Some(container) =
-                        list.parent_element().and_then(|node| {
-                            node.dyn_into::<web_sys::HtmlElement>().ok()
-                        })
-                    && let Some(selected_item) =
-                        list.children().item(selected_index as u32).and_then(
-                            |node| node.dyn_into::<web_sys::HtmlElement>().ok(),
-                        )
-                {
-                    let container_js: &JsValue = container.as_ref();
-                    let item_js: &JsValue = selected_item.as_ref();
-
-                    if let Ok(get_rect) = js_sys::Reflect::get(
-                        container_js,
-                        &JsValue::from_str("getBoundingClientRect"),
-                    ) && let Ok(func) =
-                        get_rect.dyn_into::<js_sys::Function>()
-                        && let Ok(container_rect_js) = func.call0(container_js)
-                        && let Ok(item_rect_func) = js_sys::Reflect::get(
-                            item_js,
-                            &JsValue::from_str("getBoundingClientRect"),
-                        )
-                        .and_then(|f| f.dyn_into::<js_sys::Function>())
-                        && let Ok(item_rect_js) = item_rect_func.call0(item_js)
-                    {
-                        let container_top = js_sys::Reflect::get(
-                            &container_rect_js,
-                            &JsValue::from_str("top"),
-                        )
-                        .ok()
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(0.0);
-                        let container_bottom = js_sys::Reflect::get(
-                            &container_rect_js,
-                            &JsValue::from_str("bottom"),
-                        )
-                        .ok()
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(0.0);
-                        let container_height = js_sys::Reflect::get(
-                            &container_rect_js,
-                            &JsValue::from_str("height"),
-                        )
-                        .ok()
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(0.0);
-
-                        let item_top = js_sys::Reflect::get(
-                            &item_rect_js,
-                            &JsValue::from_str("top"),
-                        )
-                        .ok()
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(0.0);
-                        let item_bottom = js_sys::Reflect::get(
-                            &item_rect_js,
-                            &JsValue::from_str("bottom"),
-                        )
-                        .ok()
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(0.0);
-                        let item_height = js_sys::Reflect::get(
-                            &item_rect_js,
-                            &JsValue::from_str("height"),
-                        )
-                        .ok()
-                        .and_then(|v| v.as_f64())
-                        .unwrap_or(0.0);
-
-                        let is_fully_visible = item_top >= container_top
-                            && item_bottom <= container_bottom;
-
-                        if !is_fully_visible {
-                            let item_center = item_top + (item_height / 2.0);
-                            let container_center =
-                                container_top + (container_height / 2.0);
-
-                            let scroll_offset = item_center - container_center;
-                            let new_scroll_top =
-                                container.scroll_top() as f64 + scroll_offset;
-
-                            container.set_scroll_top(new_scroll_top as i32);
-                        }
-                    }
-                }
-            });
-            timeout.forget();
+            if let Some(list) = list_ref.cast::<web_sys::HtmlElement>()
+                && let Some(item) =
+                    list.query_selector(".selected").ok().flatten()
+            {
+                let opts = web_sys::ScrollIntoViewOptions::new();
+                opts.set_block(web_sys::ScrollLogicalPosition::Nearest);
+                item.scroll_into_view_with_scroll_into_view_options(&opts);
+            }
         });
     }
 

--- a/lib/bombadil-inspect/src/list_autoscroll.rs
+++ b/lib/bombadil-inspect/src/list_autoscroll.rs
@@ -40,8 +40,10 @@ pub fn use_list_autoscroll(
                     }),
                 );
 
-                let js_fn: js_sys::Function =
-                    closure.as_ref().unchecked_ref::<js_sys::Function>().clone();
+                let js_fn: js_sys::Function = closure
+                    .as_ref()
+                    .unchecked_ref::<js_sys::Function>()
+                    .clone();
                 let _ = container
                     .add_event_listener_with_callback("scroll", &js_fn);
 
@@ -50,9 +52,8 @@ pub fn use_list_autoscroll(
 
             move || {
                 if let Some((container, js_fn, _closure)) = listener {
-                    let _ = container.remove_event_listener_with_callback(
-                        "scroll", &js_fn,
-                    );
+                    let _ = container
+                        .remove_event_listener_with_callback("scroll", &js_fn);
                 }
             }
         });

--- a/lib/bombadil-inspect/src/list_autoscroll.rs
+++ b/lib/bombadil-inspect/src/list_autoscroll.rs
@@ -25,27 +25,36 @@ pub fn use_list_autoscroll(
                 .and_then(|list| list.parent_element())
                 .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok());
 
-            let Some(container) = container else { return };
+            let listener = container.map(|container| {
+                let scroll_container = container.clone();
+                let closure = wasm_bindgen::closure::Closure::<dyn Fn()>::wrap(
+                    Box::new(move || {
+                        let at_bottom = scroll_container.scroll_top() as f64
+                            + scroll_container.client_height() as f64
+                            >= scroll_container.scroll_height() as f64 - 5.0;
+                        let was_following = *is_following.borrow();
+                        *is_following.borrow_mut() = at_bottom;
+                        if was_following && !at_bottom {
+                            on_select.emit(*current_index.borrow());
+                        }
+                    }),
+                );
 
-            let scroll_container = container.clone();
-            let closure = wasm_bindgen::closure::Closure::<dyn Fn()>::wrap(
-                Box::new(move || {
-                    let at_bottom = scroll_container.scroll_top() as f64
-                        + scroll_container.client_height() as f64
-                        >= scroll_container.scroll_height() as f64 - 5.0;
-                    let was_following = *is_following.borrow();
-                    *is_following.borrow_mut() = at_bottom;
-                    if was_following && !at_bottom {
-                        on_select.emit(*current_index.borrow());
-                    }
-                }),
-            );
+                let js_fn: js_sys::Function =
+                    closure.as_ref().unchecked_ref::<js_sys::Function>().clone();
+                let _ = container
+                    .add_event_listener_with_callback("scroll", &js_fn);
 
-            let _ = container.add_event_listener_with_callback(
-                "scroll",
-                closure.as_ref().unchecked_ref(),
-            );
-            closure.forget();
+                (container, js_fn, closure)
+            });
+
+            move || {
+                if let Some((container, js_fn, _closure)) = listener {
+                    let _ = container.remove_event_listener_with_callback(
+                        "scroll", &js_fn,
+                    );
+                }
+            }
         });
     }
 

--- a/lib/bombadil-inspect/src/list_autoscroll.rs
+++ b/lib/bombadil-inspect/src/list_autoscroll.rs
@@ -1,6 +1,3 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use wasm_bindgen::JsCast;
 use yew::prelude::*;
 

--- a/lib/bombadil-inspect/src/list_autoscroll.rs
+++ b/lib/bombadil-inspect/src/list_autoscroll.rs
@@ -7,7 +7,7 @@ use yew::prelude::*;
 #[hook]
 pub fn use_list_autoscroll(
     selected_index: usize,
-    is_following: Rc<RefCell<bool>>,
+    is_following: UseStateHandle<bool>,
     on_select: Callback<usize>,
 ) -> NodeRef {
     let list_ref = use_node_ref();
@@ -32,8 +32,8 @@ pub fn use_list_autoscroll(
                         let at_bottom = scroll_container.scroll_top() as f64
                             + scroll_container.client_height() as f64
                             >= scroll_container.scroll_height() as f64 - 5.0;
-                        let was_following = *is_following.borrow();
-                        *is_following.borrow_mut() = at_bottom;
+                        let was_following = *is_following;
+                        is_following.set(at_bottom);
                         if was_following && !at_bottom {
                             on_select.emit(*current_index.borrow());
                         }

--- a/lib/bombadil-inspect/src/timeline.rs
+++ b/lib/bombadil-inspect/src/timeline.rs
@@ -27,7 +27,7 @@ const T: f64 = K * K * K * K;
 
 #[derive(PartialEq, Properties)]
 pub struct TimelineProps {
-    pub entries: Rc<[TraceEntry]>,
+    pub entries: Rc<[Rc<TraceEntry>]>,
     pub test_start: Time,
     pub selected_index: usize,
     pub on_select: Callback<usize>,

--- a/lib/bombadil-schema/src/schema.rs
+++ b/lib/bombadil-schema/src/schema.rs
@@ -75,6 +75,15 @@ pub struct TraceEntry {
     pub resources: Resources,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum WsTraceEntryMessage {
+    #[serde(rename = "entry")]
+    Entry(TraceEntry),
+    #[serde(rename = "allEntries")]
+    AllEntries(Vec<TraceEntry>),
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Resources {
     pub js_heap_used: u64,

--- a/lib/bombadil-schema/src/schema.rs
+++ b/lib/bombadil-schema/src/schema.rs
@@ -30,7 +30,11 @@ impl Time {
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or_default()
             .as_micros() as u64;
-        Time(micros)
+        Self(micros)
+    }
+
+    pub fn from_micros(micros: u64) -> Self {
+        Self(micros)
     }
 
     pub fn to_system_time(self) -> SystemTime {

--- a/lib/bombadil-schema/src/schema.rs
+++ b/lib/bombadil-schema/src/schema.rs
@@ -77,6 +77,7 @@ pub struct TraceEntry {
 
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
+#[allow(clippy::large_enum_variant)] // Transit wrapper - doesn't sit around in memory. Even if it was, the small variant (AllEntries) is only used once, so you'd be wasting very little memory vs Boxing<every single Entry TraceEntry>
 pub enum WsTraceEntryMessage {
     #[serde(rename = "entry")]
     Entry(TraceEntry),

--- a/lib/bombadil/src/browser/state.rs
+++ b/lib/bombadil/src/browser/state.rs
@@ -145,7 +145,7 @@ impl std::fmt::Debug for Screenshot {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Resources {
     pub js_heap_used: u64,
     pub js_heap_total: u64,

--- a/lib/bombadil/src/specification/convert.rs
+++ b/lib/bombadil/src/specification/convert.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::specification::{
     js::RuntimeFunction,
@@ -6,7 +6,7 @@ use crate::specification::{
     verifier::Snapshot,
 };
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PrettyFunction(String);
 
 impl std::fmt::Display for PrettyFunction {

--- a/lib/bombadil/src/specification/ltl.rs
+++ b/lib/bombadil/src/specification/ltl.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use crate::specification::result::{Result, SpecificationError};
 use crate::specification::verifier::{Snapshot, merge_snapshots};
 pub use bombadil_schema::Time;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 fn combine_options<T: Clone>(
     left: Option<T>,
@@ -20,7 +20,7 @@ fn combine_options<T: Clone>(
 
 /// A formula in negation normal form (NNF), up to thunks. Note that `Implies` is preserved for
 /// better error messages.
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Formula<Function> {
     Pure { value: bool, pretty: String },
     Thunk { function: Function, negated: bool },
@@ -89,7 +89,7 @@ pub enum Value<Function> {
     Residual(Residual<Function>),
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Violation<Function> {
     False {
         time: Time,
@@ -122,7 +122,7 @@ pub enum Violation<Function> {
     },
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum EventuallyViolation {
     TimedOut(Time),
     TestEnded,

--- a/lib/bombadil/src/trace/writer.rs
+++ b/lib/bombadil/src/trace/writer.rs
@@ -43,7 +43,7 @@ impl TraceWriter {
         last_action: Option<&BrowserAction>,
         snapshots: &[Snapshot],
         violations: &[PropertyViolation],
-    ) -> Result<()> {
+    ) -> Result<bombadil_schema::TraceEntry> {
         let screenshot_path = self.screenshots_path.join(format!(
             "{}.{}",
             state.timestamp.duration_since(UNIX_EPOCH)?.as_micros(),
@@ -68,11 +68,13 @@ impl TraceWriter {
 
         self.last_transition_hash = state.transition_hash;
 
+        let entry_api = entry.to_api();
+
         self.trace_file
-            .write_all(json::to_string(&entry.to_api())?.as_bytes())
+            .write_all(json::to_string(&entry_api)?.as_bytes())
             .await?;
         self.trace_file.write_u8(b'\n').await?;
 
-        Ok(())
+        Ok(entry_api)
     }
 }


### PR DESCRIPTION
Closes https://github.com/antithesishq/bombadil/issues/135

Adds a broadcast sender to `MainObserver` that forwards all trace entries from the trace writer to a new axum websocket server.

The port number is written to a file in the output path (same dir as the trace). `bombadil inspect` grabs this and opens the browser with a `streaming-port` query param. If the param isn't present it (the frontend) falls back to just fetching the trace file like before.

New button!
<img width="300" height="218" alt="image" src="https://github.com/user-attachments/assets/600998bf-d5ce-4754-9532-76d749704182" />

Should have been a different PR but put Claude to work fixing the autoscroll list component - works now.

Btw, the list entries collection on the frontend is `Rc<[Rc<TraceEntry>]>` now because deep clones on large TraceEntry collections are expensive, and have to happen each time new trace comes in now (because use_state only gives you an immutable ref).

TODOs:
- [ ] Test with `test-external`. Should just work.
- [x] Specify the port for the ws server in `TestSharedOptions`?
- [x] Fall back to the trace file if the ws connection fails.
