### PR TITLE
widen default granted permissions for Chromium 145

### DIFF
--- a/docs/manual/src/04-reference.md
+++ b/docs/manual/src/04-reference.md
@@ -33,7 +33,7 @@
 | `--height <HEIGHT>` | Browser viewport height in pixels | 768 |
 | `--device-scale-factor <DEVICE_SCALE_FACTOR>` | Scaling factor of the browser viewport, mostly useful on high-DPI monitors when in headed mode | 2 |
 | `--instrument-javascript <INSTRUMENT_JAVASCRIPT>` | What types of JavaScript to instrument for coverage tracking. Comma-separated list of: "files", "inline" | files,inline |
-| `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access |
+| `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--headless` | Whether the browser should run in a visible window or not | |
 | `--no-sandbox` | Disable Chromium sandboxing | |
 | `-h, --help` | Print help | |
@@ -60,7 +60,7 @@
 | `--height <HEIGHT>` | Browser viewport height in pixels | 768 |
 | `--device-scale-factor <DEVICE_SCALE_FACTOR>` | Scaling factor of the browser viewport, mostly useful on high-DPI monitors when in headed mode | 2 |
 | `--instrument-javascript <INSTRUMENT_JAVASCRIPT>` | What types of JavaScript to instrument for coverage tracking. Comma-separated list of: "files", "inline" | files,inline |
-| `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access |
+| `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--remote-debugger <REMOTE_DEBUGGER>` | Address to the remote debugger's server, e.g. http://localhost:9222 | |
 | `--create-target` | Whether Bombadil should create a new tab and navigate to the origin URL in it, as part of starting the test (this should probably be false if you test an Electron app) | |
 | `-h, --help` | Print help | |

--- a/lib/bombadil-cli/src/main.rs
+++ b/lib/bombadil-cli/src/main.rs
@@ -67,7 +67,10 @@ struct TestSharedOptions {
     time_limit: Option<Duration>,
     /// Comma-separated list of Chrome permissions to grant.
     /// Examples: local-network-access, geolocation, notifications.
-    #[arg(long, default_value = "local-network-access")]
+    #[arg(
+        long,
+        default_value = "local-network-access,local-network,loopback-network"
+    )]
     chrome_grant_permissions: String,
 }
 


### PR DESCRIPTION
From the [LNA adoption guide](https://docs.google.com/document/d/1QQkqehw8umtAgz5z0um7THx-aoU251p705FbIQjDuGs/edit?pli=1&tab=t.0):

> LNA adds two new permissions to the web platform: local-network and loopback-network.
>
> The local-network permission is for requests from a public site to a site hosted on a user's local network (e.g. a router or an internal server).
>
> The loopback-network permission is for requests from a public site to an app or service hosted on the user's current device (e.g., the phone or computer which the user is currently using).
>
> These permissions work as of Chrome 145. Prior to Chrome 145, these two permissions were combined under a single local-network-access permission. Based on discussions with developers and other browser vendors, the combined permission was split into two finer-grained permissions to allow sites to request only the permission they need and allowing Chrome to have more specific permission prompts that should be more understandable to users.
>
> If you are targeting Chrome browsers older than 145, then you may need to use the older local-network-access permission name – see this FAQ entry below.

Thus, we use both the old and the new permissions to cover pre and post version 145 Chrome/Chromium.