### PR TITLE
Make CLI exit codes consistent

### DIFF
--- a/lib/bombadil-cli/src/main.rs
+++ b/lib/bombadil-cli/src/main.rs
@@ -294,10 +294,16 @@ async fn test(
         test_start: Option<bombadil_schema::Time>,
         deadline: Option<SystemTime>,
         output_path: PathBuf,
+        violations_count: u64,
+    }
+
+    enum TestResult {
+        ViolationsFound { violations_count: u64 },
+        Success,
     }
 
     impl RunObserver for MainObserver {
-        type StopValue = i32;
+        type StopValue = TestResult;
 
         async fn on_new_state(
             &mut self,
@@ -318,6 +324,7 @@ async fn test(
                 );
             }
 
+            self.violations_count += violations.len() as u64;
             for violation in violations {
                 log::info!("violation of property `{}`", violation.name);
                 let api_violation = violation.to_api();
@@ -337,15 +344,23 @@ async fn test(
                 .write(state, last_action, snapshots, violations)
                 .await?;
 
-            if !violations.is_empty() && self.exit_on_violation {
-                return Ok(ControlFlow::Stop(2));
+            if self.violations_count > 0 && self.exit_on_violation {
+                return Ok(ControlFlow::Stop(TestResult::ViolationsFound {
+                    violations_count: self.violations_count,
+                }));
             }
 
             if let Some(deadline) = self.deadline
                 && state.timestamp >= deadline
             {
                 log::info!("time limit reached, stopping");
-                return Ok(ControlFlow::Stop(0));
+                return Ok(ControlFlow::Stop(if self.violations_count > 0 {
+                    TestResult::ViolationsFound {
+                        violations_count: self.violations_count,
+                    }
+                } else {
+                    TestResult::Success
+                }));
             }
 
             Ok(ControlFlow::Continue)
@@ -367,21 +382,33 @@ async fn test(
         test_start: None,
         deadline,
         output_path: output_path.clone(),
+        violations_count: 0,
     };
 
-    let exit_code = runner.run(&mut observer).await?;
+    let test_result = runner.run(&mut observer).await?;
+
+    let heading =
+        if let Some(TestResult::ViolationsFound { violations_count }) =
+            test_result
+        {
+            styled::maybe_red(styled::maybe_bold(format!(
+                "Test finished with {} violations!",
+                violations_count
+            )))
+        } else {
+            styled::maybe_bold("Test finished!".to_string())
+        };
 
     println!(
-        "{}\n\nInspect the test results using:\n\n  {}",
-        styled::maybe_bold("Test finished!".to_string()),
+        "\n{heading}\n\nInspect the test results using:\n\n  {}",
         styled::maybe_italic(format!(
             "bombadil inspect {}",
             observer.output_path.display()
         ))
     );
 
-    if let Some(exit_code) = exit_code {
-        std::process::exit(exit_code);
+    if let Some(TestResult::ViolationsFound { .. }) = test_result {
+        std::process::exit(2);
     }
 
     Ok(())

--- a/lib/bombadil-cli/src/main.rs
+++ b/lib/bombadil-cli/src/main.rs
@@ -18,7 +18,7 @@ use bombadil::{
         actions::BrowserAction, state::BrowserState,
     },
     instrumentation::InstrumentationConfig,
-    runner::{ControlFlow, RunObserver, Runner, RunnerOptions},
+    runner::{ControlFlow, RunObserver, Runner},
     specification::verifier::{Snapshot, Specification},
     styled,
     trace::{PropertyViolation, writer::TraceWriter},
@@ -280,9 +280,6 @@ async fn test(
     let runner = Runner::new(
         shared_options.origin.url,
         specification,
-        RunnerOptions {
-            stop_on_violation: shared_options.exit_on_violation,
-        },
         browser_options,
         debugger_options,
     )

--- a/lib/bombadil-cli/src/main.rs
+++ b/lib/bombadil-cli/src/main.rs
@@ -362,6 +362,16 @@ async fn test(
 
             Ok(ControlFlow::Continue)
         }
+
+        async fn on_terminated(&mut self) -> anyhow::Result<Self::StopValue> {
+            if self.violations_count > 0 {
+                Ok(TestResult::ViolationsFound {
+                    violations_count: self.violations_count,
+                })
+            } else {
+                Ok(TestResult::Success)
+            }
+        }
     }
 
     if let Some(duration) = shared_options.time_limit {

--- a/lib/bombadil-cli/src/main.rs
+++ b/lib/bombadil-cli/src/main.rs
@@ -294,9 +294,17 @@ async fn test(
         violations_count: u64,
     }
 
-    enum TestResult {
-        ViolationsFound { violations_count: u64 },
-        Success,
+    #[derive(Clone, Copy, Debug)]
+    enum ExitReason {
+        ExitOnViolation,
+        TimeLimit,
+        Interrupted,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    struct TestResult {
+        exit_reason: ExitReason,
+        violations_count: u64,
     }
 
     impl RunObserver for MainObserver {
@@ -342,7 +350,8 @@ async fn test(
                 .await?;
 
             if self.violations_count > 0 && self.exit_on_violation {
-                return Ok(ControlFlow::Stop(TestResult::ViolationsFound {
+                return Ok(ControlFlow::Stop(TestResult {
+                    exit_reason: ExitReason::ExitOnViolation,
                     violations_count: self.violations_count,
                 }));
             }
@@ -351,26 +360,20 @@ async fn test(
                 && state.timestamp >= deadline
             {
                 log::info!("time limit reached, stopping");
-                return Ok(ControlFlow::Stop(if self.violations_count > 0 {
-                    TestResult::ViolationsFound {
-                        violations_count: self.violations_count,
-                    }
-                } else {
-                    TestResult::Success
+                return Ok(ControlFlow::Stop(TestResult {
+                    exit_reason: ExitReason::TimeLimit,
+                    violations_count: self.violations_count,
                 }));
             }
 
             Ok(ControlFlow::Continue)
         }
 
-        async fn on_terminated(&mut self) -> anyhow::Result<Self::StopValue> {
-            if self.violations_count > 0 {
-                Ok(TestResult::ViolationsFound {
-                    violations_count: self.violations_count,
-                })
-            } else {
-                Ok(TestResult::Success)
-            }
+        async fn on_interrupted(&mut self) -> anyhow::Result<Self::StopValue> {
+            Ok(TestResult {
+                exit_reason: ExitReason::Interrupted,
+                violations_count: self.violations_count,
+            })
         }
     }
 
@@ -394,17 +397,37 @@ async fn test(
 
     let test_result = runner.run(&mut observer).await?;
 
-    let heading =
-        if let Some(TestResult::ViolationsFound { violations_count }) =
-            test_result
-        {
-            styled::maybe_red(styled::maybe_bold(format!(
-                "Test finished with {} violations!",
-                violations_count
-            )))
-        } else {
-            styled::maybe_bold("Test finished!".to_string())
+    let heading = if let Some(TestResult {
+        exit_reason,
+        violations_count,
+    }) = test_result
+    {
+        let findings = match violations_count {
+            0 => "".into(),
+            1 => ", finding 1 violation".into(),
+            n => format!(", finding {n} violations"),
         };
+
+        let heading = styled::maybe_bold(match exit_reason {
+            ExitReason::ExitOnViolation => {
+                format!("Test finished{findings}!",)
+            }
+            ExitReason::TimeLimit => {
+                format!("Test finished after time limit{findings}!")
+            }
+            ExitReason::Interrupted => {
+                format!("Test was interrupted by SIGINT{findings}!",)
+            }
+        });
+
+        if violations_count > 0 {
+            styled::maybe_red(heading)
+        } else {
+            heading
+        }
+    } else {
+        styled::maybe_bold("Test finished!".to_string())
+    };
 
     println!(
         "\n{heading}\n\nInspect the test results using:\n\n  {}",
@@ -414,7 +437,9 @@ async fn test(
         ))
     );
 
-    if let Some(TestResult::ViolationsFound { .. }) = test_result {
+    if let Some(result) = test_result
+        && result.violations_count > 0
+    {
         std::process::exit(2);
     }
 

--- a/lib/bombadil/src/runner.rs
+++ b/lib/bombadil/src/runner.rs
@@ -199,6 +199,7 @@ impl Runner {
                             return Ok(Some(value));
                         }
 
+                        // TODO: remove this?
                         if has_violations && options.stop_on_violation {
                             return Ok(None);
                         }

--- a/lib/bombadil/src/runner.rs
+++ b/lib/bombadil/src/runner.rs
@@ -24,10 +24,6 @@ struct PartialSnapshot {
     value: json::Value,
 }
 
-pub struct RunnerOptions {
-    pub stop_on_violation: bool,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ControlFlow<T> {
     Continue,
@@ -50,7 +46,6 @@ pub trait RunObserver {
 
 pub struct Runner {
     origin: Url,
-    options: RunnerOptions,
     browser: Browser,
     verifier: Arc<VerifierWorker>,
 }
@@ -59,7 +54,6 @@ impl Runner {
     pub async fn new(
         origin: Url,
         specification: Specification,
-        options: RunnerOptions,
         browser_options: BrowserOptions,
         debugger_options: DebuggerOptions,
     ) -> anyhow::Result<Self> {
@@ -77,7 +71,6 @@ impl Runner {
 
         Ok(Runner {
             origin,
-            options,
             browser,
             verifier,
         })
@@ -94,7 +87,6 @@ impl Runner {
 
         let result = Runner::run_test(
             &self.origin,
-            self.options,
             &mut self.browser,
             self.verifier,
             observer,
@@ -113,7 +105,6 @@ impl Runner {
 
     async fn run_test<O: RunObserver>(
         origin: &Url,
-        options: RunnerOptions,
         browser: &mut Browser,
         verifier: Arc<VerifierWorker>,
         observer: &mut O,
@@ -166,7 +157,6 @@ impl Runner {
                                 | PropertyValue::True => {}
                             }
                         }
-                        let has_violations = !violations.is_empty();
 
                         // Make sure we stay within origin.
                         let action_tree =
@@ -199,10 +189,6 @@ impl Runner {
                             return Ok(Some(value));
                         }
 
-                        // TODO: remove this?
-                        if has_violations && options.stop_on_violation {
-                            return Ok(None);
-                        }
                         if !step_result.has_pending {
                             log::info!("all properties are definite, stopping");
                             return Ok(None);

--- a/lib/bombadil/src/runner.rs
+++ b/lib/bombadil/src/runner.rs
@@ -45,7 +45,7 @@ pub trait RunObserver {
         Output = anyhow::Result<ControlFlow<Self::StopValue>>,
     >;
 
-    fn on_terminated(
+    fn on_interrupted(
         &mut self,
     ) -> impl std::future::Future<Output = anyhow::Result<Self::StopValue>>;
 }
@@ -223,7 +223,7 @@ impl Runner {
                     }
                 },
                 _ = ctrl_c() => {
-                    let value = observer.on_terminated().await?;
+                    let value = observer.on_interrupted().await?;
                     return Ok(Some(value));
                 },
             }

--- a/lib/bombadil/src/runner.rs
+++ b/lib/bombadil/src/runner.rs
@@ -12,6 +12,8 @@ use serde_json as json;
 use std::cmp::max;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::select;
+use tokio::signal::ctrl_c;
 
 use crate::browser::state::{BrowserState, Coverage};
 use crate::browser::{Browser, DebuggerOptions};
@@ -42,6 +44,10 @@ pub trait RunObserver {
     ) -> impl std::future::Future<
         Output = anyhow::Result<ControlFlow<Self::StopValue>>,
     >;
+
+    fn on_terminated(
+        &mut self,
+    ) -> impl std::future::Future<Output = anyhow::Result<Self::StopValue>>;
 }
 
 pub struct Runner {
@@ -114,105 +120,112 @@ impl Runner {
 
         loop {
             let verifier = verifier.clone();
-            let event = browser.next_event().await;
-            match event {
-                Some(event) => match event {
-                    BrowserEvent::StateChanged(state) => {
-                        // Step formulas and collect violations.
-                        let snapshots: Arc<[Snapshot]> =
-                            run_extractors(&state, &last_action).await?.into();
-                        for value in snapshots.iter() {
-                            log::debug!(
-                                "snapshot {}: {}",
-                                value.name.as_deref().unwrap_or("<unnamed>"),
-                                value.value
-                            );
-                        }
-                        let step_result = verifier
-                            .step::<crate::specification::js::JsAction>(
-                                snapshots.clone(),
-                                bombadil_schema::Time::from_system_time(
-                                    state.timestamp,
-                                ),
-                            )
-                            .await?;
-
-                        // Convert JsAction tree to BrowserAction tree
-                        let action_tree =
-                            step_result.actions.try_map(&mut |js_action| {
-                                js_action.to_browser_action()
-                            })?;
-
-                        let mut violations =
-                            Vec::with_capacity(step_result.properties.len());
-                        for (name, value) in step_result.properties {
-                            match value {
-                                PropertyValue::False(violation) => {
-                                    violations.push(PropertyViolation {
-                                        name,
-                                        violation,
-                                    });
+            select! {
+                event = browser.next_event() => {
+                    match event {
+                        Some(event) => match event {
+                            BrowserEvent::StateChanged(state) => {
+                                // Step formulas and collect violations.
+                                let snapshots: Arc<[Snapshot]> =
+                                    run_extractors(&state, &last_action).await?.into();
+                                for value in snapshots.iter() {
+                                    log::debug!(
+                                        "snapshot {}: {}",
+                                        value.name.as_deref().unwrap_or("<unnamed>"),
+                                        value.value
+                                    );
                                 }
-                                PropertyValue::Residual
-                                | PropertyValue::True => {}
+                                let step_result = verifier
+                                    .step::<crate::specification::js::JsAction>(
+                                        snapshots.clone(),
+                                        bombadil_schema::Time::from_system_time(
+                                            state.timestamp,
+                                        ),
+                                    )
+                                    .await?;
+
+                                // Convert JsAction tree to BrowserAction tree
+                                let action_tree =
+                                    step_result.actions.try_map(&mut |js_action| {
+                                        js_action.to_browser_action()
+                                    })?;
+
+                                let mut violations =
+                                    Vec::with_capacity(step_result.properties.len());
+                                for (name, value) in step_result.properties {
+                                    match value {
+                                        PropertyValue::False(violation) => {
+                                            violations.push(PropertyViolation {
+                                                name,
+                                                violation,
+                                            });
+                                        }
+                                        PropertyValue::Residual
+                                        | PropertyValue::True => {}
+                                    }
+                                }
+
+                                // Make sure we stay within origin.
+                                let action_tree =
+                                    if !is_within_domain(&state.url, origin) {
+                                        action_tree.filter(&|a| {
+                                            matches!(a, BrowserAction::Back)
+                                        })
+                                    } else {
+                                        action_tree
+                                    };
+
+                                // Update global edges.
+                                for (index, bucket) in &state.coverage.edges_new {
+                                    edges[*index as usize] =
+                                        max(edges[*index as usize], *bucket);
+                                }
+                                log_coverage_stats_increment(&state.coverage);
+                                log_coverage_stats_total(&edges);
+
+                                let control = observer
+                                    .on_new_state(
+                                        &state,
+                                        last_action.as_ref(),
+                                        &snapshots,
+                                        &violations,
+                                    )
+                                    .await?;
+
+                                if let ControlFlow::Stop(value) = control {
+                                    return Ok(Some(value));
+                                }
+
+                                if !step_result.has_pending {
+                                    log::info!("all properties are definite, stopping");
+                                    return Ok(None);
+                                }
+
+                                let action_tree =
+                                    action_tree.prune().ok_or_else(|| {
+                                        anyhow::anyhow!("no actions available")
+                                    })?;
+
+                                let action =
+                                    action_tree.pick(&mut rand::rng())?.clone();
+                                let timeout = action_timeout(&action);
+                                log::info!("picked action: {:?}", action);
+                                browser.apply(action.clone(), timeout)?;
+                                last_action = Some(action);
                             }
+                            BrowserEvent::Error(error) => {
+                                anyhow::bail!("state machine error: {}", error)
+                            }
+                        },
+                        None => {
+                            anyhow::bail!("browser closed")
                         }
-
-                        // Make sure we stay within origin.
-                        let action_tree =
-                            if !is_within_domain(&state.url, origin) {
-                                action_tree.filter(&|a| {
-                                    matches!(a, BrowserAction::Back)
-                                })
-                            } else {
-                                action_tree
-                            };
-
-                        // Update global edges.
-                        for (index, bucket) in &state.coverage.edges_new {
-                            edges[*index as usize] =
-                                max(edges[*index as usize], *bucket);
-                        }
-                        log_coverage_stats_increment(&state.coverage);
-                        log_coverage_stats_total(&edges);
-
-                        let control = observer
-                            .on_new_state(
-                                &state,
-                                last_action.as_ref(),
-                                &snapshots,
-                                &violations,
-                            )
-                            .await?;
-
-                        if let ControlFlow::Stop(value) = control {
-                            return Ok(Some(value));
-                        }
-
-                        if !step_result.has_pending {
-                            log::info!("all properties are definite, stopping");
-                            return Ok(None);
-                        }
-
-                        let action_tree =
-                            action_tree.prune().ok_or_else(|| {
-                                anyhow::anyhow!("no actions available")
-                            })?;
-
-                        let action =
-                            action_tree.pick(&mut rand::rng())?.clone();
-                        let timeout = action_timeout(&action);
-                        log::info!("picked action: {:?}", action);
-                        browser.apply(action.clone(), timeout)?;
-                        last_action = Some(action);
-                    }
-                    BrowserEvent::Error(error) => {
-                        anyhow::bail!("state machine error: {}", error)
                     }
                 },
-                None => {
-                    anyhow::bail!("browser closed")
-                }
+                _ = ctrl_c() => {
+                    let value = observer.on_terminated().await?;
+                    return Ok(Some(value));
+                },
             }
         }
     }

--- a/lib/integration-tests/tests/integration_tests.rs
+++ b/lib/integration-tests/tests/integration_tests.rs
@@ -269,7 +269,7 @@ impl<'a> BrowserIntegrationTest<'a> {
                 Ok(bombadil::runner::ControlFlow::Continue)
             }
 
-            async fn on_terminated(
+            async fn on_interrupted(
                 &mut self,
             ) -> anyhow::Result<Self::StopValue> {
                 Ok(())

--- a/lib/integration-tests/tests/integration_tests.rs
+++ b/lib/integration-tests/tests/integration_tests.rs
@@ -813,12 +813,12 @@ export const fileActions = actions(() => {{
 
 export const fileUploaded = eventually(
   () => statusText.current === "you have uploaded a file"
-).within(5, "seconds");
+).within(20, "seconds");
 "#,
     );
 
     BrowserIntegrationTest::new("file-picker")
-        .time_limit(Duration::from_secs(10))
+        .time_limit(Duration::from_secs(30))
         .specification(&spec)
         .run()
         .await;

--- a/lib/integration-tests/tests/integration_tests.rs
+++ b/lib/integration-tests/tests/integration_tests.rs
@@ -268,6 +268,12 @@ impl<'a> BrowserIntegrationTest<'a> {
 
                 Ok(bombadil::runner::ControlFlow::Continue)
             }
+
+            async fn on_terminated(
+                &mut self,
+            ) -> anyhow::Result<Self::StopValue> {
+                Ok(())
+            }
         }
 
         let deadline = time_limit.map(|d| SystemTime::now() + d);

--- a/lib/integration-tests/tests/integration_tests.rs
+++ b/lib/integration-tests/tests/integration_tests.rs
@@ -21,7 +21,7 @@ use bombadil::{
         Browser, BrowserOptions, DebuggerOptions, Emulation, LaunchOptions,
         actions::BrowserAction,
     },
-    runner::{Runner, RunnerOptions},
+    runner::Runner,
     specification::verifier::Specification,
     styled,
 };
@@ -196,9 +196,6 @@ impl<'a> BrowserIntegrationTest<'a> {
         let runner = Runner::new(
             origin,
             specification,
-            RunnerOptions {
-                stop_on_violation: true,
-            },
             BrowserOptions {
                 create_target: true,
                 emulation: Emulation {
@@ -259,6 +256,7 @@ impl<'a> BrowserIntegrationTest<'a> {
                             violation.name, rendered
                         ));
                     }
+                    return Ok(bombadil::runner::ControlFlow::Stop(()));
                 }
 
                 if let Some(deadline) = self.deadline


### PR DESCRIPTION
This PR unifies the handling and rendering of exit codes and
reasons:

- tracks count of violations found and print relevant heading at end
- handle ctrl+c (SIGINT) in runner
- removes runner options (all handled by observer now)

Closes #136.
