### PR TITLE
remove .at() and time cell

### DIFF
--- a/docs/manual/src/03-specification-language.md
+++ b/docs/manual/src/03-specification-language.md
@@ -378,10 +378,10 @@ export const max_notifications_shown = always(() =>
 
 ### Sliding window: constant notification count
 
-This property checks that the notification count doesn't change ---
-that it is the same as in the first state. Note how this property
-evaluates `time.current` in the outer thunk, and then uses that
-time value to look up older values.
+This property checks that the notification count doesn't change --- that it is
+the same as in the first state. Note how this property evaluates
+`notificationCount.current` in the outer thunk, and then uses that in the
+inner thunk to compare against the current value.
 
 ```typescript
 import { extract, always, now, time } from "@antithesishq/bombadil";
@@ -392,9 +392,9 @@ const notificationCount = extract((state) =>
 );
 
 export const constantNotificationCount = now(() => {
-    const start = time.current;
+    const initial = notificationCount.current;
     return always(() => 
-        notificationCount.current === notification_count.at(start),
+        notificationCount.current === initial,
     );
 });
 ```

--- a/lib/bombadil/src/runner.rs
+++ b/lib/bombadil/src/runner.rs
@@ -277,19 +277,6 @@ async fn run_extractors(
         )
         .await?;
 
-    // Update time cell in browser runtime before running extractors
-    let timestamp_millis = state
-        .timestamp
-        .duration_since(std::time::UNIX_EPOCH)?
-        .as_millis() as u64;
-
-    state
-        .evaluate_function_call::<json::Value>(
-            "(timestamp) => { const { time } = __bombadilRequire('@antithesishq/bombadil'); time.update(null, timestamp); return true; }",
-            vec![json::json!(timestamp_millis)],
-        )
-        .await?;
-
     let partial_snapshots: Vec<PartialSnapshot> = state
             .evaluate_function_call(
                 "(state) => __bombadilRequire('@antithesishq/bombadil').runtime.runExtractors({ ...state, document, window })",

--- a/lib/bombadil/src/snapshots/bombadil__styled__tests__bounded_always.snap
+++ b/lib/bombadil/src/snapshots/bombadil__styled__tests__bounded_always.snap
@@ -2,4 +2,4 @@
 source: lib/bombadil/src/styled.rs
 expression: render_violation(&violation)
 ---
-as of [1m00:00.000[0m, it should always be the case that for 10 seconds [3mnotificationCount.current === notificationCount.at(start)[0m, however as of [1m02:00.000[0m and until [1m02:10.000[0m, it should always be the case that [3mnotificationCount.current === notificationCount.at(start)[0m, however at [1m02:05.000[0m, notificationCount = [34m3[39m
+as of [1m00:00.000[0m, it should always be the case that for 10 seconds [3mnotificationCount.current === initial[0m, however as of [1m02:00.000[0m and until [1m02:10.000[0m, it should always be the case that [3mnotificationCount.current === initial[0m, however at [1m02:05.000[0m, notificationCount = [34m3[39m

--- a/lib/bombadil/src/specification/bundler/snapshots/bombadil__specification__bundler__tests__bundle.snap
+++ b/lib/bombadil/src/specification/bundler/snapshots/bombadil__specification__bundler__tests__bundle.snap
@@ -389,20 +389,6 @@ expression: bundle
     			return value;
     		}
     	}
-    	at(other) {
-    		this.runtime.recordAccess(this.index);
-    		if (other < time.current) {
-    			const value = this.snapshots.get(other);
-    			if (value === void 0) {
-    				throw new Error("cannot get value from unknown time");
-    			}
-    			return value;
-    		} else if (time.current < other) {
-    			throw new Error("cannot get cell value from the future");
-    		} else {
-    			return this.current;
-    		}
-    	}
     	named(name) {
     		this.name = name;
     		return this;
@@ -422,9 +408,6 @@ expression: bundle
     			throw new Error("time has not been set");
     		}
     		return this.time;
-    	}
-    	at(time2) {
-    		return time2;
     	}
     }
     const time = new TimeCell();

--- a/lib/bombadil/src/specification/bundler/snapshots/bombadil__specification__bundler__tests__bundle.snap
+++ b/lib/bombadil/src/specification/bundler/snapshots/bombadil__specification__bundler__tests__bundle.snap
@@ -131,7 +131,6 @@ expression: bundle
   modules["@antithesishq/bombadil"] = function(module, exports, require) {
     module.exports.__esModule=true;const { ExtractorCell, Runtime } = __bombadilRequire("@antithesishq/bombadil/internal");
     const runtime = new Runtime();
-    const { time } = __bombadilRequire("@antithesishq/bombadil/internal");
     const { actions, weighted, ActionGenerator, from, strings, emails, integers, keycodes } = __bombadilRequire("@antithesishq/bombadil/actions");
     class Formula {
     	not() {
@@ -313,7 +312,6 @@ expression: bundle
     module.exports.now = now;
     module.exports.runtime = runtime;
     module.exports.strings = strings;
-    module.exports.time = time;
     module.exports.weighted = weighted;
   };
 
@@ -375,18 +373,17 @@ expression: bundle
     	}
     	name = null;
     	index;
-    	snapshots = /* @__PURE__ */ new Map();
-    	update(snapshot, time2) {
-    		this.snapshots.set(time2, snapshot);
+    	snapshot;
+    	update(snapshot) {
+    		this.snapshot = snapshot;
     	}
     	get current() {
     		this.runtime.checkNotExtracting();
     		this.runtime.recordAccess(this.index);
-    		const value = this.snapshots.get(time.current);
-    		if (value === void 0) {
-    			throw new Error(`no cell value available in current state (this is a bug in the runtime)`);
+    		if (this.snapshot === void 0) {
+    			throw new Error(`snapshot ${this.name} is not set for current state (this is a bug in the runtime)`);
     		} else {
-    			return value;
+    			return this.snapshot;
     		}
     	}
     	named(name) {
@@ -397,20 +394,6 @@ expression: bundle
     		return this.extract(state);
     	}
     }
-    class TimeCell {
-    	time = void 0;
-    	constructor() {}
-    	update(_, time2) {
-    		this.time = time2;
-    	}
-    	get current() {
-    		if (this.time === void 0) {
-    			throw new Error("time has not been set");
-    		}
-    		return this.time;
-    	}
-    }
-    const time = new TimeCell();
     class Runtime {
     	extractors = [];
     	extractingDepth = 0;
@@ -459,8 +442,6 @@ expression: bundle
     ;
     module.exports.ExtractorCell = ExtractorCell;
     module.exports.Runtime = Runtime;
-    module.exports.TimeCell = TimeCell;
-    module.exports.time = time;
   };
 
   modules["@antithesishq/bombadil/random"] = function(module, exports, require) {

--- a/lib/bombadil/src/specification/index.ts
+++ b/lib/bombadil/src/specification/index.ts
@@ -10,7 +10,7 @@ import {
 export const runtime = new Runtime<State>();
 
 // Reexports
-export { time, type Cell } from "@antithesishq/bombadil/internal";
+export { type Cell } from "@antithesishq/bombadil/internal";
 export {
   actions,
   weighted,

--- a/lib/bombadil/src/specification/internal.ts
+++ b/lib/bombadil/src/specification/internal.ts
@@ -4,7 +4,6 @@ export type TimeUnit = "milliseconds" | "seconds";
 
 export interface Cell<T> {
   get current(): T;
-  at(time: Time): T;
   update(snapshot: T, time: Time): void;
 }
 
@@ -20,7 +19,7 @@ export type JSON =
 export class ExtractorCell<T extends JSON, S> implements Cell<T> {
   public name: string | null = null;
   public readonly index: number;
-  private snapshots = new Map<Time, T>();
+  private snapshot = [Time, T];
   constructor(
     private runtime: Runtime<S>,
     private extract: (state: S) => T,
@@ -29,34 +28,19 @@ export class ExtractorCell<T extends JSON, S> implements Cell<T> {
   }
 
   update(snapshot: T, time: Time): void {
-    this.snapshots.set(time, snapshot);
+    this.snapshot = [time, snapshot];
   }
 
   get current(): T {
     this.runtime.checkNotExtracting();
     this.runtime.recordAccess(this.index);
-    const value = this.snapshots.get(time.current);
-    if (value === undefined) {
+    const [snapshotTime, snapshotValue] = this.snapshot;
+    if (time.current !== snapshotTime) {
       throw new Error(
-        `no cell value available in current state (this is a bug in the runtime)`,
+        `snapshot ${this.name} not available in current state (this is a bug in the runtime)`,
       );
     } else {
       return value;
-    }
-  }
-
-  at(other: Time): T {
-    this.runtime.recordAccess(this.index);
-    if (other < time.current) {
-      const value = this.snapshots.get(other);
-      if (value === undefined) {
-        throw new Error("cannot get value from unknown time");
-      }
-      return value;
-    } else if (time.current < other) {
-      throw new Error("cannot get cell value from the future");
-    } else {
-      return this.current;
     }
   }
 
@@ -83,10 +67,6 @@ export class TimeCell implements Cell<Time> {
       throw new Error("time has not been set");
     }
     return this.time;
-  }
-
-  at(time: Time): Time {
-    return time;
   }
 }
 

--- a/lib/bombadil/src/specification/internal.ts
+++ b/lib/bombadil/src/specification/internal.ts
@@ -1,10 +1,8 @@
-export type Time = number;
-
 export type TimeUnit = "milliseconds" | "seconds";
 
 export interface Cell<T> {
   get current(): T;
-  update(snapshot: T, time: Time): void;
+  update(snapshot: T): void;
 }
 
 export type JSON =
@@ -19,7 +17,8 @@ export type JSON =
 export class ExtractorCell<T extends JSON, S> implements Cell<T> {
   public name: string | null = null;
   public readonly index: number;
-  private snapshot = [Time, T];
+  private snapshot: T | undefined;
+
   constructor(
     private runtime: Runtime<S>,
     private extract: (state: S) => T,
@@ -27,20 +26,19 @@ export class ExtractorCell<T extends JSON, S> implements Cell<T> {
     this.index = runtime.registerExtractor(this);
   }
 
-  update(snapshot: T, time: Time): void {
-    this.snapshot = [time, snapshot];
+  update(snapshot: T): void {
+    this.snapshot = snapshot;
   }
 
   get current(): T {
     this.runtime.checkNotExtracting();
     this.runtime.recordAccess(this.index);
-    const [snapshotTime, snapshotValue] = this.snapshot;
-    if (time.current !== snapshotTime) {
+    if (this.snapshot === undefined) {
       throw new Error(
-        `snapshot ${this.name} not available in current state (this is a bug in the runtime)`,
+        `snapshot ${this.name} is not set for current state (this is a bug in the runtime)`,
       );
     } else {
-      return value;
+      return this.snapshot;
     }
   }
 
@@ -53,24 +51,6 @@ export class ExtractorCell<T extends JSON, S> implements Cell<T> {
     return this.extract(state);
   }
 }
-
-export class TimeCell implements Cell<Time> {
-  private time: Time | undefined = undefined;
-  constructor() {}
-
-  update(_: {}, time: Time) {
-    this.time = time;
-  }
-
-  get current(): Time {
-    if (this.time === undefined) {
-      throw new Error("time has not been set");
-    }
-    return this.time;
-  }
-}
-
-export const time: Cell<Time> = new TimeCell();
 
 export class Runtime<S> {
   extractors: ExtractorCell<any, S>[] = [];

--- a/lib/bombadil/src/specification/js.rs
+++ b/lib/bombadil/src/specification/js.rs
@@ -6,7 +6,6 @@ use boa_engine::{
 };
 
 use serde::{Deserialize, Serialize};
-use serde_json as json;
 
 use crate::browser::actions::BrowserAction;
 use crate::geometry::Point;
@@ -307,7 +306,6 @@ pub struct BombadilExports {
     pub always: JsValue,
     pub eventually: JsValue,
     pub runtime: JsObject,
-    pub time: JsObject,
     pub action_generator: JsValue,
 }
 
@@ -339,11 +337,6 @@ impl BombadilExports {
                     "runtime is not an object".to_string(),
                 ),
             )?,
-            time: get_export("time")?.as_object().ok_or(
-                SpecificationError::OtherError(
-                    "time is not an object".to_string(),
-                ),
-            )?,
             action_generator: get_export("ActionGenerator")?,
         })
     }
@@ -373,11 +366,6 @@ impl BombadilExports {
                     "runtime is not an object".to_string(),
                 ),
             )?,
-            time: get_export("time")?.as_object().ok_or(
-                SpecificationError::OtherError(
-                    "time is not an object".to_string(),
-                ),
-            )?,
             action_generator: get_export("ActionGenerator")?,
         })
     }
@@ -397,15 +385,11 @@ pub fn module_exports(
 
 pub struct Extractors {
     instances: Vec<JsObject>,
-    time: JsObject,
 }
 
 impl Extractors {
-    pub fn new(bombadil_exports: &BombadilExports) -> Self {
-        Self {
-            instances: vec![],
-            time: bombadil_exports.time.clone(),
-        }
+    pub fn new() -> Self {
+        Self { instances: vec![] }
     }
 
     pub fn register(&mut self, obj: JsObject) {
@@ -419,12 +403,10 @@ impl Extractors {
     pub fn update_from_snapshots(
         &self,
         snapshots: &[Snapshot],
-        time: bombadil_schema::Time,
         context: &mut Context,
     ) -> Result<()> {
         let update = |extractor: &JsObject,
                       value: JsValue,
-                      time: JsValue,
                       context: &mut Context|
          -> Result<()> {
             let method = extractor
@@ -435,32 +417,25 @@ impl Extractors {
                 ))?;
             method.call(
                 &JsValue::from(extractor.clone()),
-                &[value, time],
+                &[value],
                 context,
             )?;
             Ok(())
         };
 
-        let time = JsValue::from_json(
-            &json::Value::Number(
-                json::Number::from_u128(time.as_micros() as u128).ok_or(
-                    SpecificationError::OtherError(
-                        "conversion from Time to number failed".to_string(),
-                    ),
-                )?,
-            ),
-            context,
-        )?;
-
-        update(&self.time, JsValue::null(), time.clone(), context)?;
-
         for (index, snapshot) in snapshots.iter().enumerate() {
             if let Some(obj) = self.get(index) {
                 let js_value = JsValue::from_json(&snapshot.value, context)?;
-                update(obj, js_value, time.clone(), context)?;
+                update(obj, js_value, context)?;
             }
         }
         Ok(())
+    }
+}
+
+impl Default for Extractors {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/lib/bombadil/src/specification/verifier.rs
+++ b/lib/bombadil/src/specification/verifier.rs
@@ -253,7 +253,7 @@ impl Verifier {
             ));
         }
 
-        let mut extractors = Extractors::new(&bombadil_exports);
+        let mut extractors = Extractors::default();
 
         let extractors_value = bombadil_exports
             .runtime
@@ -295,11 +295,8 @@ impl Verifier {
         snapshots: &[Snapshot],
         time: ltl::Time,
     ) -> Result<StepResult<A>> {
-        self.extractors.update_from_snapshots(
-            snapshots,
-            time,
-            &mut self.context,
-        )?;
+        self.extractors
+            .update_from_snapshots(snapshots, &mut self.context)?;
         let mut result_properties = Vec::with_capacity(self.properties.len());
         let mut generator_branches: Vec<(u16, Tree<A>)> = Vec::new();
 

--- a/lib/bombadil/src/styled.rs
+++ b/lib/bombadil/src/styled.rs
@@ -470,9 +470,7 @@ mod tests {
             name: "constantNotificationCount".to_string(),
             violation: Violation::Always {
                 subformula: Box::new(Formula::Always(
-                    Box::new(thunk(
-                        "notificationCount.current === notificationCount.at(start)",
-                    )),
+                    Box::new(thunk("notificationCount.current === initial")),
                     Some(Duration::from_secs(10)),
                 )),
                 start: time_at(0),
@@ -480,16 +478,15 @@ mod tests {
                 time: time_at(120),
                 violation: Box::new(Violation::Always {
                     subformula: Box::new(thunk(
-                        "notificationCount.current === notificationCount.at(start)",
+                        "notificationCount.current === initial",
                     )),
                     start: time_at(120),
                     end: Some(time_at(130)),
                     time: time_at(125),
                     violation: Box::new(Violation::False {
                         time: time_at(125),
-                        condition:
-                            "notificationCount.current === notificationCount.at(start)"
-                                .into(),
+                        condition: "notificationCount.current === initial"
+                            .into(),
                         snapshots: vec![Snapshot {
                             index: 0,
                             name: Some("notificationCount".into()),

--- a/lib/integration-tests/tests/integration_tests.rs
+++ b/lib/integration-tests/tests/integration_tests.rs
@@ -592,30 +592,6 @@ export const counterStateMachine = always(unchanged.or(increment).or(decrement))
 }
 
 #[tokio::test]
-async fn test_time_extractor() {
-    BrowserIntegrationTest::new("time-extractor")
-        .time_limit(Duration::from_secs(10))
-        .specification(
-            r##"
-import { actions, extract, now, eventually, time } from "@antithesishq/bombadil";
-export { clicks } from "@antithesishq/bombadil/defaults/actions";
-
-const myTime = extract((state) => time.current);
-
-// Property: time is a reasonable value (after year 2020)
-export const timeIsReasonable = now(() => {
-  const start = myTime.current;
-  return eventually(() =>
-      myTime.current > start
-  );
-});
-"##,
-        )
-        .run()
-        .await;
-}
-
-#[tokio::test]
 async fn test_extractor_exception_stack_trace() {
     BrowserIntegrationTest::new("extractor-exception")
         .expect_error("\n    at throwingFunction")


### PR DESCRIPTION
This removes the `.at()` method on cells, as well as the `time` cell.
Instead of an unbounded map `time -> snapshot` we only set the 
current snapshot during property and action evaluation. To implement
sliding window properties, users may close over snapshots in temporal
operators with thunks.

The `time` cell thus became irrelevant, because it was opaque in the
first place. Time-bounded operators are available already through
the `.within()` method on `always` and `eventually` formulas.

Closes #130.
