### PR TITLE
Quiescence timers instead of fixed timeouts

### DIFF
--- a/lib/bombadil-cli/src/main.rs
+++ b/lib/bombadil-cli/src/main.rs
@@ -56,7 +56,7 @@ struct TestSharedOptions {
     height: u16,
     /// Scaling factor of the browser viewport, mostly useful on high-DPI monitors when in headed
     /// mode
-    #[arg(long, default_value_t = 2.0)]
+    #[arg(long, default_value_t = 1.0)]
     device_scale_factor: f64,
     /// What types of JavaScript to instrument for coverage tracking.
     /// Comma-separated list of: "files", "inline"

--- a/lib/bombadil-inspect/src/screenshot.rs
+++ b/lib/bombadil-inspect/src/screenshot.rs
@@ -55,10 +55,8 @@ pub fn Screenshot(props: &ScreenshotProps) -> Html {
                 .as_deref()
                 .and_then(action_point)
                 .map(|point| {
-                    // TODO: this needs to be part of test metadata
-                    let device_scale_factor = 2.0;
-                    let x = point.x * device_scale_factor * transform.scale;
-                    let y = point.y * device_scale_factor * transform.scale;
+                    let x = point.x * transform.scale;
+                    let y = point.y * transform.scale;
                     let radius = 20.0_f64;
                     let diameter = 2.0 * radius;
                     html!(

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -142,12 +142,11 @@ impl std::fmt::Display for Generation {
     }
 }
 
-const QUIESCENCE_BUMP: Duration = Duration::from_millis(50);
 /// Initial idle timeout before the first activity signal arrives.
 /// Deliberately long so we don't fire before the browser has produced
-/// any frames; the first screencast bump will replace this with a
-/// much shorter deadline.
-const QUIESCENCE_INITIAL_IDLE: Duration = Duration::from_millis(32);
+/// any frames; the first activity event will replace this with a much shorter
+/// deadline.
+const QUIESCENCE_INITIAL_IDLE: Duration = Duration::from_millis(500);
 const QUIESCENCE_TIMEOUT: Duration = Duration::from_secs(10);
 const NAVIGATION_TIMEOUT: Duration = Duration::from_secs(30);
 

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -144,7 +144,7 @@ impl std::fmt::Display for Generation {
 /// Deliberately long so we don't fire before the browser has produced
 /// any frames; the first activity event will replace this with a much shorter
 /// deadline.
-const QUIESCENCE_INITIAL_IDLE: Duration = Duration::from_millis(500);
+const QUIESCENCE_INITIAL_IDLE: Duration = Duration::from_millis(250);
 const QUIESCENCE_TIMEOUT: Duration = Duration::from_secs(10);
 const NAVIGATION_TIMEOUT: Duration = Duration::from_secs(30);
 

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -29,13 +29,13 @@ use tokio_stream::wrappers::BroadcastStream;
 use url::Url;
 
 use crate::browser::actions::BrowserAction;
-use crate::browser::quiescence::QuiescenceTimer;
 use crate::browser::state::{
     BrowserState, CallFrame, ConsoleEntry, Exception, Screenshot,
     ScreenshotFormat,
 };
 
 pub mod actions;
+pub mod activity;
 pub mod evaluation;
 pub mod instrumentation;
 pub mod quiescence;
@@ -68,8 +68,8 @@ enum InnerStateKind {
     Resuming(BrowserAction),
     Navigating { url: String },
     Loading,
-    Running(QuiescenceTimer),
-    Acting(QuiescenceTimer),
+    Running(quiescence::QuiescenceTimer),
+    Acting,
 }
 
 impl std::fmt::Debug for InnerStateKind {
@@ -85,7 +85,7 @@ impl std::fmt::Debug for InnerStateKind {
             }
             Self::Loading => write!(f, "Loading"),
             Self::Running(_) => write!(f, "Running"),
-            Self::Acting(_) => write!(f, "Acting"),
+            Self::Acting => write!(f, "Acting"),
         }
     }
 }
@@ -116,9 +116,6 @@ enum InnerEvent {
     ActionAccepted(BrowserAction),
     ActionApplied(Generation),
     ExceptionThrown(Exception),
-    /// An underlying browser activity (network, DOM mutation, etc.)
-    /// occurred. Used to bump the quiescence timer.
-    Activity,
     /// The quiescence timer has fired — the browser has settled.
     Quiesced(Generation),
     /// The navigation timeout fired — give up waiting for Loaded.
@@ -147,7 +144,7 @@ impl std::fmt::Display for Generation {
     }
 }
 
-const QUIESCENCE_BUMP: Duration = Duration::from_millis(10);
+const QUIESCENCE_BUMP: Duration = Duration::from_millis(50);
 const QUIESCENCE_TIMEOUT: Duration = Duration::from_secs(10);
 const NAVIGATION_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -158,6 +155,7 @@ struct BrowserContext {
     shutdown_receiver: oneshot::Receiver<()>,
     page: Arc<Page>,
     frame_id: FrameId,
+    network_activity: activity::NetworkActivity,
     #[allow(unused, reason = "this is going into the scripts soon")]
     origin: Url,
 }
@@ -330,6 +328,9 @@ impl Browser {
             .await?
             .ok_or(anyhow!("no main frame available"))?;
 
+        let network_activity =
+            activity::NetworkActivity::subscribe(&page).await?;
+
         let context = BrowserContext {
             sender,
             actions_sender: actions_sender.clone(),
@@ -337,6 +338,7 @@ impl Browser {
             shutdown_receiver,
             page: page.clone(),
             frame_id,
+            network_activity,
             origin: origin.clone(),
         };
 
@@ -733,39 +735,6 @@ async fn inner_events(
             .map(InnerEvent::ActionAccepted),
     );
 
-    // Activity events for quiescence detection.
-    let activity_network_request = Box::pin(
-        context
-            .page
-            .event_listener::<network::EventRequestWillBeSent>()
-            .await?
-            .map(|_| InnerEvent::Activity),
-    ) as InnerEventStream;
-
-    let activity_network_response = Box::pin(
-        context
-            .page
-            .event_listener::<network::EventResponseReceived>()
-            .await?
-            .map(|_| InnerEvent::Activity),
-    ) as InnerEventStream;
-
-    let activity_network_loading_finished = Box::pin(
-        context
-            .page
-            .event_listener::<network::EventLoadingFinished>()
-            .await?
-            .map(|_| InnerEvent::Activity),
-    ) as InnerEventStream;
-
-    let activity_network_loading_failed = Box::pin(
-        context
-            .page
-            .event_listener::<network::EventLoadingFailed>()
-            .await?
-            .map(|_| InnerEvent::Activity),
-    ) as InnerEventStream;
-
     Ok(Box::pin(stream::select_all(vec![
         events_loaded,
         events_paused,
@@ -777,10 +746,6 @@ async fn inner_events(
         events_target_destroyed,
         events_console,
         events_action_accepted,
-        activity_network_request,
-        activity_network_response,
-        activity_network_loading_finished,
-        activity_network_loading_failed,
     ])))
 }
 
@@ -794,6 +759,7 @@ fn run_state_machine(
             let shared = InnerStateShared::default();
             let timer = start_quiescence_timer(
                 &shared,
+                &context.network_activity,
                 &context.inner_events_sender,
             );
             let mut state_current = InnerState {
@@ -885,6 +851,7 @@ async fn process_event(
                 .await?;
             let timer = start_quiescence_timer(
                 &state.shared,
+                &context.network_activity,
                 &context.inner_events_sender,
             );
             capture_browser_state(
@@ -1043,23 +1010,23 @@ async fn process_event(
             });
 
             shared.console_entries.clear();
-            let timer =
-                start_quiescence_timer(&shared, &context.inner_events_sender);
             InnerState {
-                kind: Acting(timer),
+                kind: Acting,
                 shared,
             }
         }
         (
             InnerState {
-                kind: Acting(timer),
+                kind: Acting,
                 shared,
             },
             InnerEvent::ActionApplied(generation),
         ) if shared.generation == generation => {
-            // Bump the existing timer — the action completing is
-            // activity, so reset the idle countdown.
-            timer.bump();
+            let timer = start_quiescence_timer(
+                &shared,
+                &context.network_activity,
+                &context.inner_events_sender,
+            );
             InnerState {
                 kind: Running(timer),
                 shared,
@@ -1070,8 +1037,11 @@ async fn process_event(
             state
         }
         (InnerState { shared, .. }, InnerEvent::Loaded) => {
-            let timer =
-                start_quiescence_timer(&shared, &context.inner_events_sender);
+            let timer = start_quiescence_timer(
+                &shared,
+                &context.network_activity,
+                &context.inner_events_sender,
+            );
             InnerState {
                 kind: Running(timer),
                 shared,
@@ -1109,19 +1079,11 @@ async fn process_event(
             }
         }
         (
-            InnerState {
-                kind:
-                    Navigating {
-                        url: url_navigating,
-                    },
-                shared,
-            },
-            InnerEvent::DownloadWillBegin {
-                url: url_download,
-                frame_id,
-            },
+            InnerState { kind, shared },
+            InnerEvent::DownloadWillBegin { frame_id, url },
         ) => {
-            if frame_id == context.frame_id && url_navigating == url_download {
+            if frame_id == context.frame_id {
+                log::debug!("download started: {}", url);
                 let _ = context.inner_events_sender.send(
                     InnerEvent::StateRequested(
                         StateRequestReason::FileDownload,
@@ -1130,6 +1092,7 @@ async fn process_event(
                 );
                 let timer = start_quiescence_timer(
                     &shared,
+                    &context.network_activity,
                     &context.inner_events_sender,
                 );
                 InnerState {
@@ -1137,12 +1100,7 @@ async fn process_event(
                     shared,
                 }
             } else {
-                InnerState {
-                    kind: Navigating {
-                        url: url_navigating,
-                    },
-                    shared,
-                }
+                InnerState { kind, shared }
             }
         }
         (
@@ -1178,6 +1136,7 @@ async fn process_event(
                     NavigationType::BackForwardCacheRestore => {
                         let timer = start_quiescence_timer(
                             &state.shared,
+                            &context.network_activity,
                             &context.inner_events_sender,
                         );
                         Running(timer)
@@ -1198,18 +1157,11 @@ async fn process_event(
                 state
             }
         }
-        (state, InnerEvent::Activity) => {
-            match &state.kind {
-                Running(timer) | Acting(timer) => timer.bump(),
-                _ => {}
-            }
-            state
-        }
         (state, InnerEvent::Quiesced(generation)) => {
             if state.shared.generation != generation {
                 log::debug!("ignoring stale Quiesced event");
                 state
-            } else if matches!(state.kind, Running(_) | Acting(_)) {
+            } else if matches!(state.kind, Running(_)) {
                 log::debug!("quiesced, requesting new state capture");
                 let _ = context.inner_events_sender.send(
                     InnerEvent::StateRequested(
@@ -1234,6 +1186,7 @@ async fn process_event(
                 );
                 let timer = start_quiescence_timer(
                     &state.shared,
+                    &context.network_activity,
                     &context.inner_events_sender,
                 );
                 InnerState {
@@ -1252,18 +1205,36 @@ async fn process_event(
 
 fn start_quiescence_timer(
     shared: &InnerStateShared,
+    network_activity: &activity::NetworkActivity,
     inner_events_sender: &Sender<InnerEvent>,
-) -> QuiescenceTimer {
-    let (timer, waiter) =
-        QuiescenceTimer::new(QUIESCENCE_BUMP, QUIESCENCE_TIMEOUT);
+) -> quiescence::QuiescenceTimer {
+    let activity = network_activity.stream();
+    let (timer, quiescent) =
+        quiescence::start(QUIESCENCE_BUMP, QUIESCENCE_TIMEOUT, activity);
     let generation = shared.generation;
     let sender = inner_events_sender.clone();
     spawn(async move {
-        waiter.wait().await;
-        log::debug!("quiescence timer fired for generation {}", generation);
-        let _ = sender.send(InnerEvent::Quiesced(generation));
+        if quiescent.await {
+            log::debug!("quiescence timer fired for generation {}", generation);
+            let _ = sender.send(InnerEvent::Quiesced(generation));
+        }
     });
     timer
+}
+
+fn retry_with_timer(
+    shared: InnerStateShared,
+    context: &BrowserContext,
+) -> InnerState {
+    let timer = start_quiescence_timer(
+        &shared,
+        &context.network_activity,
+        &context.inner_events_sender,
+    );
+    InnerState {
+        kind: InnerStateKind::Running(timer),
+        shared,
+    }
 }
 
 async fn capture_browser_state(
@@ -1272,21 +1243,12 @@ async fn capture_browser_state(
 ) -> Result<InnerState> {
     log::debug!("pausing, going into next generation...");
 
-    let retry = |shared: InnerStateShared| -> InnerState {
-        let timer =
-            start_quiescence_timer(&shared, &context.inner_events_sender);
-        InnerState {
-            kind: InnerStateKind::Running(timer),
-            shared,
-        }
-    };
-
     let page = context.page.clone();
     let main_execution_context_id = match page.execution_context().await? {
         Some(ctx) => ctx,
         None => {
             log::debug!("no execution context, skipping state capture");
-            return Ok(retry(state.shared));
+            return Ok(retry_with_timer(state.shared, context));
         }
     };
 
@@ -1307,11 +1269,11 @@ async fn capture_browser_state(
         Ok(Ok(data)) => Screenshot { data, format },
         Ok(Err(error)) => {
             log::warn!("screenshot failed: {}, skipping state capture", error);
-            return Ok(retry(state.shared));
+            return Ok(retry_with_timer(state.shared, context));
         }
         Err(_) => {
             log::warn!("screenshot timed out, skipping state capture");
-            return Ok(retry(state.shared));
+            return Ok(retry_with_timer(state.shared, context));
         }
     };
     state.shared.screenshot = Some(screenshot);

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -984,18 +984,6 @@ async fn process_event(
                         )
                     }
                 }
-                // Wait two animation frames so the renderer flushes
-                // pending input events (e.g. focus changes from mouse
-                // clicks) before signalling that the action is done.
-                let _ = page
-                    .execute(
-                        runtime::EvaluateParams::builder()
-                            .expression("new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))")
-                            .await_promise(true)
-                            .build()
-                            .unwrap(),
-                    )
-                    .await;
                 if let Err(error) =
                     sender.send(InnerEvent::ActionApplied(shared.generation))
                 {

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -1,12 +1,12 @@
 use anyhow::{Context, Result, anyhow, bail};
 use chromiumoxide::browser::BrowserConfigBuilder;
 use chromiumoxide::cdp::browser_protocol::browser;
+use chromiumoxide::cdp::browser_protocol::emulation;
 use chromiumoxide::cdp::browser_protocol::network;
 use chromiumoxide::cdp::browser_protocol::page::{
     self, ClientNavigationReason, FrameId, NavigationType,
 };
 use chromiumoxide::cdp::browser_protocol::target::{self, TargetId};
-use chromiumoxide::cdp::browser_protocol::{dom, emulation};
 use chromiumoxide::cdp::js_protocol::debugger::{self, CallFrameId};
 use chromiumoxide::cdp::js_protocol::runtime::{self};
 use chromiumoxide::page::ScreenshotParams;
@@ -29,6 +29,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use url::Url;
 
 use crate::browser::actions::BrowserAction;
+use crate::browser::quiescence::QuiescenceTimer;
 use crate::browser::state::{
     BrowserState, CallFrame, ConsoleEntry, Exception, Screenshot,
     ScreenshotFormat,
@@ -37,6 +38,7 @@ use crate::browser::state::{
 pub mod actions;
 pub mod evaluation;
 pub mod instrumentation;
+pub mod quiescence;
 pub mod state;
 
 #[derive(Debug, Clone)]
@@ -60,15 +62,32 @@ struct InnerState {
     shared: InnerStateShared,
 }
 
-#[derive(Debug)]
 enum InnerStateKind {
     Pausing,
     Paused,
-    Resuming(BrowserAction, Timeout),
+    Resuming(BrowserAction),
     Navigating { url: String },
     Loading,
-    Running,
-    Acting,
+    Running(QuiescenceTimer),
+    Acting(QuiescenceTimer),
+}
+
+impl std::fmt::Debug for InnerStateKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pausing => write!(f, "Pausing"),
+            Self::Paused => write!(f, "Paused"),
+            Self::Resuming(action) => {
+                f.debug_tuple("Resuming").field(action).finish()
+            }
+            Self::Navigating { url } => {
+                f.debug_struct("Navigating").field("url", url).finish()
+            }
+            Self::Loading => write!(f, "Loading"),
+            Self::Running(_) => write!(f, "Running"),
+            Self::Acting(_) => write!(f, "Acting"),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -94,19 +113,23 @@ enum InnerEvent {
     },
     TargetDestroyed(TargetId),
     ConsoleEntry(ConsoleEntry),
-    ActionAccepted(BrowserAction, Timeout),
+    ActionAccepted(BrowserAction),
     ActionApplied(Generation),
     ExceptionThrown(Exception),
+    /// An underlying browser activity (network, DOM mutation, etc.)
+    /// occurred. Used to bump the quiescence timer.
+    Activity,
+    /// The quiescence timer has fired — the browser has settled.
+    Quiesced(Generation),
+    /// The navigation timeout fired — give up waiting for Loaded.
+    NavigationTimedOut(Generation),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum StateRequestReason {
     Start,
-    Timeout,
-    Loaded,
-    BackForwardCacheRestore,
+    Quiesced,
     FileDownload,
-    Watchdog,
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
@@ -124,11 +147,13 @@ impl std::fmt::Display for Generation {
     }
 }
 
-type Timeout = Duration;
+const QUIESCENCE_BUMP: Duration = Duration::from_millis(10);
+const QUIESCENCE_TIMEOUT: Duration = Duration::from_secs(10);
+const NAVIGATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 struct BrowserContext {
     sender: Sender<BrowserEvent>,
-    actions_sender: Sender<(BrowserAction, Timeout)>,
+    actions_sender: Sender<BrowserAction>,
     inner_events_sender: Sender<InnerEvent>,
     shutdown_receiver: oneshot::Receiver<()>,
     page: Arc<Page>,
@@ -170,7 +195,7 @@ pub enum DebuggerOptions {
 pub struct Browser {
     receiver: Receiver<BrowserEvent>,
     inner_events_sender: Sender<InnerEvent>,
-    actions_sender: Sender<(BrowserAction, Timeout)>,
+    actions_sender: Sender<BrowserAction>,
     shutdown_sender: Option<oneshot::Sender<()>>,
     done_receiver: Option<oneshot::Receiver<()>>,
     browser: Option<chromiumoxide::Browser>,
@@ -222,7 +247,7 @@ impl Browser {
 
         let (sender, receiver) = channel::<BrowserEvent>(1);
 
-        let (actions_sender, _) = channel::<(BrowserAction, Timeout)>(1);
+        let (actions_sender, _) = channel::<BrowserAction>(1);
 
         let page = if browser_options.create_target {
             Arc::new(browser.new_page("about:blank").await.context(
@@ -236,6 +261,7 @@ impl Browser {
         page.enable_css().await?;
         page.enable_runtime().await?;
         page.enable_debugger().await?;
+        page.execute(network::EnableParams::default()).await?;
 
         if !browser_options.extra_headers.is_empty() {
             page.execute(network::SetExtraHttpHeadersParams::new(
@@ -404,12 +430,8 @@ impl Browser {
         }
     }
 
-    pub fn apply(
-        &mut self,
-        action: BrowserAction,
-        timeout: Timeout,
-    ) -> Result<()> {
-        self.actions_sender.send((action, timeout))?;
+    pub fn apply(&mut self, action: BrowserAction) -> Result<()> {
+        self.actions_sender.send(action)?;
         Ok(())
     }
 
@@ -546,39 +568,67 @@ async fn inner_events(
             }),
     ) as InnerEventStream;
 
+    let frame_id = context.frame_id.clone();
     let events_frame_requested_navigation = Box::pin(
         context
             .page
             .event_listener::<page::EventFrameRequestedNavigation>()
             .await?
-            .map(|nav| InnerEvent::FrameRequestedNavigation {
-                frame_id: nav.frame_id.clone(),
-                reason: nav.reason.clone(),
-                url: nav.url.clone(),
+            .filter_map(move |nav| {
+                let frame_id = frame_id.clone();
+                async move {
+                    if nav.frame_id == frame_id {
+                        None
+                    } else {
+                        Some(InnerEvent::FrameRequestedNavigation {
+                            frame_id: nav.frame_id.clone(),
+                            reason: nav.reason.clone(),
+                            url: nav.url.clone(),
+                        })
+                    }
+                }
             }),
     ) as InnerEventStream;
 
+    let frame_id_for_nav = context.frame_id.clone();
     let events_frame_navigated = Box::pin(
         context
             .page
             .event_listener::<page::EventFrameNavigated>()
             .await?
-            .map(|nav| {
-                InnerEvent::FrameNavigated(
-                    nav.frame.id.clone(),
-                    nav.r#type.clone(),
-                )
+            .filter_map(move |nav| {
+                let frame_id = frame_id_for_nav.clone();
+                async move {
+                    if nav.frame.id == frame_id {
+                        Some(InnerEvent::FrameNavigated(
+                            nav.frame.id.clone(),
+                            nav.r#type.clone(),
+                        ))
+                    } else {
+                        None
+                    }
+                }
             }),
     ) as InnerEventStream;
 
+    let frame_id_for_dl = context.frame_id.clone();
     let events_download_will_begin = Box::pin(
         context
             .page
             .event_listener::<browser::EventDownloadWillBegin>()
             .await?
-            .map(|event| InnerEvent::DownloadWillBegin {
-                frame_id: event.frame_id.clone(),
-                url: event.url.clone(),
+            .filter_map(move |event| {
+                let frame_id = frame_id_for_dl.clone();
+                async move {
+                    if event.frame_id == frame_id {
+                        Some(InnerEvent::DownloadWillBegin {
+                            frame_id: event.frame_id.clone(),
+                            url: event.url.clone(),
+                        })
+                    } else {
+                        None
+                    }
+                }
             }),
     ) as InnerEventStream;
 
@@ -678,10 +728,43 @@ async fn inner_events(
             }),
     ) as InnerEventStream;
 
-    let events_action_accepted =
-        Box::pin(receiver_to_stream(context.actions_sender.subscribe()).map(
-            |(action, timeout)| InnerEvent::ActionAccepted(action, timeout),
-        ));
+    let events_action_accepted = Box::pin(
+        receiver_to_stream(context.actions_sender.subscribe())
+            .map(InnerEvent::ActionAccepted),
+    );
+
+    // Activity events for quiescence detection.
+    let activity_network_request = Box::pin(
+        context
+            .page
+            .event_listener::<network::EventRequestWillBeSent>()
+            .await?
+            .map(|_| InnerEvent::Activity),
+    ) as InnerEventStream;
+
+    let activity_network_response = Box::pin(
+        context
+            .page
+            .event_listener::<network::EventResponseReceived>()
+            .await?
+            .map(|_| InnerEvent::Activity),
+    ) as InnerEventStream;
+
+    let activity_network_loading_finished = Box::pin(
+        context
+            .page
+            .event_listener::<network::EventLoadingFinished>()
+            .await?
+            .map(|_| InnerEvent::Activity),
+    ) as InnerEventStream;
+
+    let activity_network_loading_failed = Box::pin(
+        context
+            .page
+            .event_listener::<network::EventLoadingFailed>()
+            .await?
+            .map(|_| InnerEvent::Activity),
+    ) as InnerEventStream;
 
     Ok(Box::pin(stream::select_all(vec![
         events_loaded,
@@ -692,12 +775,12 @@ async fn inner_events(
         events_frame_navigated,
         events_download_will_begin,
         events_target_destroyed,
-        // events_node_inserted,
-        // events_node_count_updated,
-        // events_node_removed,
-        // events_attribute_modified,
         events_console,
         events_action_accepted,
+        activity_network_request,
+        activity_network_response,
+        activity_network_loading_finished,
+        activity_network_loading_failed,
     ])))
 }
 
@@ -708,7 +791,15 @@ fn run_state_machine(
 ) {
     spawn(async move {
         let result = async {
-            let mut state_current = InnerState { kind: InnerStateKind::Running, shared: InnerStateShared::default()};
+            let shared = InnerStateShared::default();
+            let timer = start_quiescence_timer(
+                &shared,
+                &context.inner_events_sender,
+            );
+            let mut state_current = InnerState {
+                kind: InnerStateKind::Running(timer),
+                shared,
+            };
             log::info!("processing events");
             loop {
                 select! {
@@ -792,9 +883,13 @@ async fn process_event(
                 .page
                 .execute(debugger::ResumeParams::builder().build())
                 .await?;
+            let timer = start_quiescence_timer(
+                &state.shared,
+                &context.inner_events_sender,
+            );
             capture_browser_state(
                 InnerState {
-                    kind: InnerStateKind::Running,
+                    kind: InnerStateKind::Running(timer),
                     shared: state.shared,
                 },
                 context,
@@ -824,6 +919,7 @@ async fn process_event(
                 exceptions,
                 generation,
                 screenshot,
+                ..
             } = state.shared;
 
             let screenshot = screenshot
@@ -844,16 +940,6 @@ async fn process_event(
 
             let generation = generation.next();
 
-            // Watchdog: if nothing happens for 30s, force a new state capture.
-            let sender = context.inner_events_sender.clone();
-            spawn(async move {
-                sleep(Duration::from_secs(30)).await;
-                let _ = sender.send(InnerEvent::StateRequested(
-                    StateRequestReason::Watchdog,
-                    generation,
-                ));
-            });
-
             InnerState {
                 kind: Paused,
                 shared: InnerStateShared {
@@ -869,14 +955,14 @@ async fn process_event(
                 kind: Paused,
                 shared,
             },
-            InnerEvent::ActionAccepted(browser_action, timeout),
+            InnerEvent::ActionAccepted(browser_action),
         ) => {
             context
                 .page
                 .execute(debugger::ResumeParams::builder().build())
                 .await?;
             InnerState {
-                kind: Resuming(browser_action, timeout),
+                kind: Resuming(browser_action),
                 shared,
             }
         }
@@ -885,7 +971,7 @@ async fn process_event(
                 kind: Loading | Navigating { .. } | Pausing,
                 ..
             },
-            InnerEvent::ActionAccepted(action, _),
+            InnerEvent::ActionAccepted(action),
         ) => {
             log::debug!(
                 "ignoring action {:?} received during {:?}",
@@ -909,7 +995,7 @@ async fn process_event(
         }
         (
             InnerState {
-                kind: Running,
+                kind: Running(timer),
                 mut shared,
             },
             InnerEvent::Resumed,
@@ -917,24 +1003,25 @@ async fn process_event(
             log::warn!("running + resumed");
             shared.console_entries.clear();
             InnerState {
-                kind: Running,
+                kind: Running(timer),
                 shared,
             }
         }
         (
             InnerState {
-                kind: Resuming(browser_action, timeout),
+                kind: Resuming(browser_action),
                 mut shared,
             },
             InnerEvent::Resumed,
         ) => {
             let page = context.page.clone();
             let sender = context.inner_events_sender.clone();
-            // We can't block on running the action, in case it synchronously
-            // throws an uncaught exception blocking the evaluation indefinitely.
-            // This gives us a chance to receive the "Debugger.paused" event and
-            // resume (extracting the uncaught exception information).
-            let action_handle = spawn(async move {
+            // We can't block on running the action, in case it
+            // synchronously throws an uncaught exception blocking the
+            // evaluation indefinitely. This gives us a chance to
+            // receive the "Debugger.paused" event and resume
+            // (extracting the uncaught exception information).
+            spawn(async move {
                 log::debug!("applying: {:?}", browser_action);
                 match browser_action.apply(&page).await {
                     Ok(_) => {
@@ -955,54 +1042,38 @@ async fn process_event(
                 }
             });
 
-            let sender = context.inner_events_sender.clone();
-            spawn(async move {
-                sleep(timeout).await;
-                action_handle.abort();
-                log::debug!(
-                    "timeout after {}ms, aborted action, requesting new state",
-                    timeout.as_millis()
-                );
-                if let Err(error) = sender.send(InnerEvent::StateRequested(
-                    StateRequestReason::Timeout,
-                    shared.generation,
-                )) {
-                    log::error!(
-                        "failed to send StateRequested after timeout: {}",
-                        error
-                    );
-                }
-            });
-
             shared.console_entries.clear();
+            let timer =
+                start_quiescence_timer(&shared, &context.inner_events_sender);
             InnerState {
-                kind: Acting,
+                kind: Acting(timer),
                 shared,
             }
         }
         (
             InnerState {
-                kind: Acting,
+                kind: Acting(timer),
                 shared,
             },
             InnerEvent::ActionApplied(generation),
-        ) if shared.generation == generation => InnerState {
-            kind: Running,
-            shared,
-        },
+        ) if shared.generation == generation => {
+            // Bump the existing timer — the action completing is
+            // activity, so reset the idle countdown.
+            timer.bump();
+            InnerState {
+                kind: Running(timer),
+                shared,
+            }
+        }
         (state, InnerEvent::ActionApplied(_)) => {
             log::debug!("ignoring stale ActionApplied");
             state
         }
         (InnerState { shared, .. }, InnerEvent::Loaded) => {
-            context
-                .inner_events_sender
-                .send(InnerEvent::StateRequested(
-                    StateRequestReason::Loaded,
-                    shared.generation,
-                ))?;
+            let timer =
+                start_quiescence_timer(&shared, &context.inner_events_sender);
             InnerState {
-                kind: Running,
+                kind: Running(timer),
                 shared,
             }
         }
@@ -1022,6 +1093,13 @@ async fn process_event(
                     kind,
                     shared.generation,
                 );
+                let generation = shared.generation;
+                let sender = context.inner_events_sender.clone();
+                spawn(async move {
+                    sleep(NAVIGATION_TIMEOUT).await;
+                    let _ =
+                        sender.send(InnerEvent::NavigationTimedOut(generation));
+                });
                 InnerState {
                     kind: Navigating { url },
                     shared,
@@ -1050,8 +1128,12 @@ async fn process_event(
                         shared.generation,
                     ),
                 );
+                let timer = start_quiescence_timer(
+                    &shared,
+                    &context.inner_events_sender,
+                );
                 InnerState {
-                    kind: Running,
+                    kind: Running(timer),
                     shared,
                 }
             } else {
@@ -1083,40 +1165,28 @@ async fn process_event(
         }
         (mut state, InnerEvent::ExceptionThrown(exception)) => {
             state.shared.exceptions.push(exception);
-            if matches!(state.kind, Running) {
+            if matches!(state.kind, Running(_)) {
                 capture_browser_state(state, context).await?
             } else {
                 state
             }
         }
         (state, InnerEvent::FrameNavigated(frame_id, navigation_type)) => {
-            // Track all nodes.
-            context
-                .page
-                .execute(
-                    dom::GetDocumentParams::builder()
-                        .depth(-1)
-                        .pierce(true)
-                        .build(),
-                )
-                .await?;
             if frame_id == context.frame_id {
-                let shared = state.shared;
                 let kind = match navigation_type {
                     NavigationType::Navigation => Loading,
-                    // Navigating history with bfcache doesn't yield a "loaded"
-                    // event so we jump straight into `Running`.
                     NavigationType::BackForwardCacheRestore => {
-                        context.inner_events_sender.send(
-                            InnerEvent::StateRequested(
-                                StateRequestReason::BackForwardCacheRestore,
-                                shared.generation,
-                            ),
-                        )?;
-                        Running
+                        let timer = start_quiescence_timer(
+                            &state.shared,
+                            &context.inner_events_sender,
+                        );
+                        Running(timer)
                     }
                 };
-                InnerState { kind, shared }
+                InnerState {
+                    kind,
+                    shared: state.shared,
+                }
             } else {
                 state
             }
@@ -1128,10 +1198,72 @@ async fn process_event(
                 state
             }
         }
+        (state, InnerEvent::Activity) => {
+            match &state.kind {
+                Running(timer) | Acting(timer) => timer.bump(),
+                _ => {}
+            }
+            state
+        }
+        (state, InnerEvent::Quiesced(generation)) => {
+            if state.shared.generation != generation {
+                log::debug!("ignoring stale Quiesced event");
+                state
+            } else if matches!(state.kind, Running(_) | Acting(_)) {
+                log::debug!("quiesced, requesting new state capture");
+                let _ = context.inner_events_sender.send(
+                    InnerEvent::StateRequested(
+                        StateRequestReason::Quiesced,
+                        state.shared.generation,
+                    ),
+                );
+                state
+            } else {
+                log::debug!("ignoring Quiesced during {:?}", &state.kind,);
+                state
+            }
+        }
+        (state, InnerEvent::NavigationTimedOut(generation)) => {
+            if state.shared.generation != generation {
+                log::debug!("ignoring stale NavigationTimedOut");
+                state
+            } else if matches!(state.kind, Navigating { .. } | Loading) {
+                log::warn!(
+                    "navigation timed out during {:?}, resuming",
+                    &state.kind,
+                );
+                let timer = start_quiescence_timer(
+                    &state.shared,
+                    &context.inner_events_sender,
+                );
+                InnerState {
+                    kind: Running(timer),
+                    shared: state.shared,
+                }
+            } else {
+                state
+            }
+        }
         (state, event) => {
             bail!("unhandled transition: {:?} + {:?}", state, event);
         }
     })
+}
+
+fn start_quiescence_timer(
+    shared: &InnerStateShared,
+    inner_events_sender: &Sender<InnerEvent>,
+) -> QuiescenceTimer {
+    let (timer, waiter) =
+        QuiescenceTimer::new(QUIESCENCE_BUMP, QUIESCENCE_TIMEOUT);
+    let generation = shared.generation;
+    let sender = inner_events_sender.clone();
+    spawn(async move {
+        waiter.wait().await;
+        log::debug!("quiescence timer fired for generation {}", generation);
+        let _ = sender.send(InnerEvent::Quiesced(generation));
+    });
+    timer
 }
 
 async fn capture_browser_state(
@@ -1140,14 +1272,21 @@ async fn capture_browser_state(
 ) -> Result<InnerState> {
     log::debug!("pausing, going into next generation...");
 
+    let retry = |shared: InnerStateShared| -> InnerState {
+        let timer =
+            start_quiescence_timer(&shared, &context.inner_events_sender);
+        InnerState {
+            kind: InnerStateKind::Running(timer),
+            shared,
+        }
+    };
+
     let page = context.page.clone();
     let main_execution_context_id = match page.execution_context().await? {
         Some(ctx) => ctx,
         None => {
-            log::debug!(
-                "no execution context available, skipping state capture"
-            );
-            return Ok(state);
+            log::debug!("no execution context, skipping state capture");
+            return Ok(retry(state.shared));
         }
     };
 
@@ -1168,19 +1307,15 @@ async fn capture_browser_state(
         Ok(Ok(data)) => Screenshot { data, format },
         Ok(Err(error)) => {
             log::warn!("screenshot failed: {}, skipping state capture", error);
-            return Ok(state);
+            return Ok(retry(state.shared));
         }
         Err(_) => {
             log::warn!("screenshot timed out, skipping state capture");
-            return Ok(state);
+            return Ok(retry(state.shared));
         }
     };
     state.shared.screenshot = Some(screenshot);
 
-    // context
-    //     .page
-    //     .execute(debugger::PauseParams::default())
-    //     .await?;
     let page = context.page.clone();
     spawn(async move {
         let _ = page

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -115,9 +115,7 @@ enum InnerEvent {
     ActionAccepted(BrowserAction),
     ActionApplied(Generation),
     ExceptionThrown(Exception),
-    /// The quiescence timer has fired — the browser has settled.
     Quiesced(Generation),
-    /// The navigation timeout fired — give up waiting for Loaded.
     NavigationTimedOut(Generation),
 }
 
@@ -637,14 +635,14 @@ async fn inner_events(
             }),
     ) as InnerEventStream;
 
-    let frame_id_for_nav = context.frame_id.clone();
+    let frame_id = context.frame_id.clone();
     let events_frame_navigated = Box::pin(
         context
             .page
             .event_listener::<page::EventFrameNavigated>()
             .await?
             .filter_map(move |nav| {
-                let frame_id = frame_id_for_nav.clone();
+                let frame_id = frame_id.clone();
                 async move {
                     if nav.frame.id == frame_id {
                         Some(InnerEvent::FrameNavigated(
@@ -658,14 +656,14 @@ async fn inner_events(
             }),
     ) as InnerEventStream;
 
-    let frame_id_for_dl = context.frame_id.clone();
+    let frame_id = context.frame_id.clone();
     let events_download_will_begin = Box::pin(
         context
             .page
             .event_listener::<browser::EventDownloadWillBegin>()
             .await?
             .filter_map(move |event| {
-                let frame_id = frame_id_for_dl.clone();
+                let frame_id = frame_id.clone();
                 async move {
                     if event.frame_id == frame_id {
                         Some(InnerEvent::DownloadWillBegin {
@@ -686,67 +684,6 @@ async fn inner_events(
             .await?
             .map(|event| InnerEvent::TargetDestroyed(event.target_id.clone())),
     ) as InnerEventStream;
-
-    // let events_node_inserted = Box::pin(
-    //     context
-    //         .page
-    //         .event_listener::<dom::EventChildNodeInserted>()
-    //         .await?
-    //         .map(|event| {
-    //             InnerEvent::NodeTreeModified(
-    //                 NodeModification::ChildNodeInserted {
-    //                     parent: event.parent_node_id,
-    //                     child: event.node.clone(),
-    //                 },
-    //             )
-    //         }),
-    // ) as InnerEventStream;
-
-    // let events_node_count_updated = Box::pin(
-    //     context
-    //         .page
-    //         .event_listener::<dom::EventChildNodeCountUpdated>()
-    //         .await?
-    //         .map(|event| {
-    //             InnerEvent::NodeTreeModified(
-    //                 NodeModification::ChildNodeCountUpdated {
-    //                     parent: event.node_id,
-    //                     count: event.child_node_count as u64,
-    //                 },
-    //             )
-    //         }),
-    // ) as InnerEventStream;
-
-    // let events_node_removed = Box::pin(
-    //     context
-    //         .page
-    //         .event_listener::<dom::EventChildNodeRemoved>()
-    //         .await?
-    //         .map(|event| {
-    //             InnerEvent::NodeTreeModified(
-    //                 NodeModification::ChildNodeRemoved {
-    //                     parent: event.parent_node_id,
-    //                     child: event.node_id,
-    //                 },
-    //             )
-    //         }),
-    // ) as InnerEventStream;
-
-    // let events_attribute_modified = Box::pin(
-    //     context
-    //         .page
-    //         .event_listener::<dom::EventAttributeModified>()
-    //         .await?
-    //         .map(|event| {
-    //             InnerEvent::NodeTreeModified(
-    //                 NodeModification::AttributeModified {
-    //                     node: event.node_id,
-    //                     name: event.name.clone(),
-    //                     value: event.value.clone(),
-    //                 },
-    //             )
-    //         }),
-    // ) as InnerEventStream;
 
     let events_console = Box::pin(
         context
@@ -1067,7 +1004,6 @@ async fn process_event(
             });
 
             shared.console_entries.clear();
-            // context.screencast_activity.restart().await;
             let activity = Box::pin(stream::select(
                 context.network_activity.stream(),
                 context.screencast_activity.stream(),
@@ -1324,7 +1260,11 @@ async fn capture_browser_state(
         }
     };
 
-    let frame = context.latest_frame.lock().unwrap().clone();
+    let frame = context
+        .latest_frame
+        .lock()
+        .expect("failed getting latest frame from mutex")
+        .clone();
     match frame {
         Some(data) => {
             state.shared.screenshot = Some(Screenshot {
@@ -1333,9 +1273,7 @@ async fn capture_browser_state(
             });
         }
         None => {
-            log::debug!(
-                "no screencast frame available, skipping state capture"
-            );
+            log::warn!("no screencast frame available, skipping state capture");
             return Ok(retry_with_timer(state.shared, context));
         }
     }

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -157,7 +157,7 @@ struct BrowserContext {
     frame_id: FrameId,
     network_activity: activity::NetworkActivity,
     screencast_activity: activity::ScreencastActivity,
-    latest_frame: Arc<Mutex<Option<Arc<Vec<u8>>>>>,
+    latest_frame: Arc<Mutex<Option<Arc<[u8]>>>>,
     #[allow(unused, reason = "this is going into the scripts soon")]
     origin: Url,
 }
@@ -343,7 +343,7 @@ impl Browser {
         let screencast_activity =
             activity::ScreencastActivity::new(screencast.clone());
 
-        let latest_frame: Arc<Mutex<Option<Arc<Vec<u8>>>>> =
+        let latest_frame: Arc<Mutex<Option<Arc<[u8]>>>> =
             Arc::new(Mutex::new(None));
 
         // Background task to keep the latest screencast frame updated.
@@ -1257,7 +1257,7 @@ async fn capture_browser_state(
         Some(data) => {
             state.shared.screenshot = Some(Screenshot {
                 format: ScreenshotFormat::Jpeg,
-                data: (*data).clone(),
+                data: data.to_vec(),
             });
         }
         None => {

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -358,9 +358,9 @@ impl Browser {
                         Ok(frame) => {
                             *latest_frame.lock().unwrap() = Some(frame);
                         }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(
-                            n,
-                        )) => {
+                        Err(
+                            tokio::sync::broadcast::error::RecvError::Lagged(n),
+                        ) => {
                             log::debug!(
                                 "screencast frame receiver lagged by {}",
                                 n
@@ -896,7 +896,7 @@ async fn process_event(
                 .await?;
             let timer = start_quiescence_timer(
                 &state.shared,
-                &context,
+                context,
                 &context.inner_events_sender,
             );
             capture_browser_state(
@@ -1102,7 +1102,7 @@ async fn process_event(
         (InnerState { shared, .. }, InnerEvent::Loaded) => {
             let timer = start_quiescence_timer(
                 &shared,
-                &context,
+                context,
                 &context.inner_events_sender,
             );
             InnerState {

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -1295,22 +1295,24 @@ fn start_quiescence_timer_from_subscription(
     timer
 }
 
-fn retry_with_timer(
-    shared: InnerStateShared,
-    context: &BrowserContext,
-) -> InnerState {
-    let timer =
-        start_quiescence_timer(&shared, context, &context.inner_events_sender);
-    InnerState {
-        kind: InnerStateKind::Running(timer),
-        shared,
-    }
-}
-
 async fn capture_browser_state(
     mut state: InnerState,
     context: &BrowserContext,
 ) -> Result<InnerState> {
+    fn retry_with_timer(
+        shared: InnerStateShared,
+        context: &BrowserContext,
+    ) -> InnerState {
+        let timer = start_quiescence_timer(
+            &shared,
+            context,
+            &context.inner_events_sender,
+        );
+        InnerState {
+            kind: InnerStateKind::Running(timer),
+            shared,
+        }
+    }
     log::debug!("pausing, going into next generation...");
 
     let page = context.page.clone();

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -159,7 +159,6 @@ struct BrowserContext {
     shutdown_receiver: oneshot::Receiver<()>,
     page: Arc<Page>,
     frame_id: FrameId,
-    #[allow(unused, reason = "will be exposed in BrowserState")]
     network_activity: activity::NetworkActivity,
     screencast_activity: activity::ScreencastActivity,
     #[allow(unused, reason = "this is going into the scripts soon")]
@@ -1032,8 +1031,11 @@ async fn process_event(
 
             shared.console_entries.clear();
             context.screencast_activity.restart().await;
-            let subscription =
-                quiescence::subscribe(context.screencast_activity.stream());
+            let activity = Box::pin(stream::select(
+                context.network_activity.stream(),
+                context.screencast_activity.stream(),
+            )) as activity::ActivityStream;
+            let subscription = quiescence::subscribe(activity);
             InnerState {
                 kind: Acting(subscription),
                 shared,
@@ -1226,8 +1228,11 @@ fn start_quiescence_timer(
     context: &BrowserContext,
     inner_events_sender: &Sender<InnerEvent>,
 ) -> quiescence::QuiescenceTimer {
-    let subscription =
-        quiescence::subscribe(context.screencast_activity.stream());
+    let activity = Box::pin(stream::select(
+        context.network_activity.stream(),
+        context.screencast_activity.stream(),
+    )) as activity::ActivityStream;
+    let subscription = quiescence::subscribe(activity);
     start_quiescence_timer_from_subscription(
         shared,
         inner_events_sender,

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -126,7 +126,6 @@ enum InnerEvent {
 enum StateRequestReason {
     Start,
     Quiesced,
-    FileDownload,
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
@@ -1104,30 +1103,24 @@ async fn process_event(
             }
         }
         (
-            InnerState { kind, shared },
+            InnerState {
+                kind: Navigating { .. },
+                shared,
+            },
             InnerEvent::DownloadWillBegin { frame_id, url },
-        ) => {
-            if frame_id == context.frame_id {
-                log::debug!("download started: {}", url);
-                let _ = context.inner_events_sender.send(
-                    InnerEvent::StateRequested(
-                        StateRequestReason::FileDownload,
-                        shared.generation,
-                    ),
-                );
-                let timer = start_quiescence_timer(
-                    &shared,
-                    context,
-                    &context.inner_events_sender,
-                );
-                InnerState {
-                    kind: Running(timer),
-                    shared,
-                }
-            } else {
-                InnerState { kind, shared }
+        ) if frame_id == context.frame_id => {
+            log::debug!("download started: {}", url);
+            let timer = start_quiescence_timer(
+                &shared,
+                context,
+                &context.inner_events_sender,
+            );
+            InnerState {
+                kind: Running(timer),
+                shared,
             }
         }
+        (state, InnerEvent::DownloadWillBegin { .. }) => state,
         (
             InnerState {
                 kind: Navigating { url },

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -9,7 +9,6 @@ use chromiumoxide::cdp::browser_protocol::page::{
 use chromiumoxide::cdp::browser_protocol::target::{self, TargetId};
 use chromiumoxide::cdp::js_protocol::debugger::{self, CallFrameId};
 use chromiumoxide::cdp::js_protocol::runtime::{self};
-use chromiumoxide::page::ScreenshotParams;
 use chromiumoxide::{BrowserConfig, Page};
 use futures::{StreamExt, stream};
 use log;
@@ -17,7 +16,7 @@ use serde_json as json;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, UNIX_EPOCH};
 use tempfile::TempDir;
 use tokio::sync::broadcast::error::RecvError;
@@ -161,6 +160,7 @@ struct BrowserContext {
     frame_id: FrameId,
     network_activity: activity::NetworkActivity,
     screencast_activity: activity::ScreencastActivity,
+    latest_frame: Arc<Mutex<Option<Arc<Vec<u8>>>>>,
     #[allow(unused, reason = "this is going into the scripts soon")]
     origin: Url,
 }
@@ -335,8 +335,45 @@ impl Browser {
 
         let network_activity =
             activity::NetworkActivity::subscribe(&page).await?;
+        let screencast = Arc::new(
+            activity::Screencast::start(
+                &page,
+                browser_options.emulation.width,
+                browser_options.emulation.height,
+            )
+            .await?,
+        );
         let screencast_activity =
-            activity::ScreencastActivity::subscribe(&page).await?;
+            activity::ScreencastActivity::new(screencast.clone());
+
+        let latest_frame: Arc<Mutex<Option<Arc<Vec<u8>>>>> =
+            Arc::new(Mutex::new(None));
+
+        // Background task to keep the latest screencast frame updated.
+        {
+            let latest_frame = latest_frame.clone();
+            let mut receiver = screencast.subscribe();
+            spawn(async move {
+                loop {
+                    match receiver.recv().await {
+                        Ok(frame) => {
+                            *latest_frame.lock().unwrap() = Some(frame);
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(
+                            n,
+                        )) => {
+                            log::debug!(
+                                "screencast frame receiver lagged by {}",
+                                n
+                            );
+                        }
+                        Err(
+                            tokio::sync::broadcast::error::RecvError::Closed,
+                        ) => break,
+                    }
+                }
+            });
+        }
 
         let context = BrowserContext {
             sender,
@@ -347,6 +384,7 @@ impl Browser {
             frame_id,
             network_activity,
             screencast_activity,
+            latest_frame,
             origin: origin.clone(),
         };
 
@@ -1030,7 +1068,7 @@ async fn process_event(
             });
 
             shared.console_entries.clear();
-            context.screencast_activity.restart().await;
+            // context.screencast_activity.restart().await;
             let activity = Box::pin(stream::select(
                 context.network_activity.stream(),
                 context.screencast_activity.stream(),
@@ -1285,37 +1323,21 @@ async fn capture_browser_state(
         }
     };
 
-    // log::debug!("taking screenshot before pause");
-    // let format = ScreenshotFormat::Webp;
-    // let screenshot_result = tokio::time::timeout(
-    //     Duration::from_secs(2),
-    //     context.page.screenshot(
-    //         ScreenshotParams::builder()
-    //             .omit_background(true)
-    //             .format(format)
-    //             .build(),
-    //     ),
-    // )
-    // .await;
-
-    // let screenshot = match screenshot_result {
-    //     Ok(Ok(data)) => Screenshot { data, format },
-    //     Ok(Err(error)) => {
-    //         log::warn!("screenshot failed: {}, skipping state capture", error);
-    //         return Ok(retry_with_timer(state.shared, context));
-    //     }
-    //     Err(_) => {
-    //         log::warn!("screenshot timed out, skipping state capture");
-    //         return Ok(retry_with_timer(state.shared, context));
-    //     }
-    // };
-    // state.shared.screenshot = Some(screenshot);
-
-    // Fake for now.
-    state.shared.screenshot = Some(Screenshot {
-        format: ScreenshotFormat::Webp,
-        data: vec![],
-    });
+    let frame = context.latest_frame.lock().unwrap().clone();
+    match frame {
+        Some(data) => {
+            state.shared.screenshot = Some(Screenshot {
+                format: ScreenshotFormat::Jpeg,
+                data: (*data).clone(),
+            });
+        }
+        None => {
+            log::debug!(
+                "no screencast frame available, skipping state capture"
+            );
+            return Ok(retry_with_timer(state.shared, context));
+        }
+    }
 
     let page = context.page.clone();
     spawn(async move {

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -69,7 +69,7 @@ enum InnerStateKind {
     Navigating { url: String },
     Loading,
     Running(quiescence::QuiescenceTimer),
-    Acting,
+    Acting(quiescence::QuiescenceSubscription),
 }
 
 impl std::fmt::Debug for InnerStateKind {
@@ -85,7 +85,7 @@ impl std::fmt::Debug for InnerStateKind {
             }
             Self::Loading => write!(f, "Loading"),
             Self::Running(_) => write!(f, "Running"),
-            Self::Acting => write!(f, "Acting"),
+            Self::Acting(_) => write!(f, "Acting"),
         }
     }
 }
@@ -149,7 +149,7 @@ const QUIESCENCE_BUMP: Duration = Duration::from_millis(50);
 /// Deliberately long so we don't fire before the browser has produced
 /// any frames; the first screencast bump will replace this with a
 /// much shorter deadline.
-const QUIESCENCE_INITIAL_IDLE: Duration = Duration::from_secs(5);
+const QUIESCENCE_INITIAL_IDLE: Duration = Duration::from_millis(32);
 const QUIESCENCE_TIMEOUT: Duration = Duration::from_secs(10);
 const NAVIGATION_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -1032,22 +1032,25 @@ async fn process_event(
             });
 
             shared.console_entries.clear();
+            context.screencast_activity.restart().await;
+            let subscription =
+                quiescence::subscribe(context.screencast_activity.stream());
             InnerState {
-                kind: Acting,
+                kind: Acting(subscription),
                 shared,
             }
         }
         (
             InnerState {
-                kind: Acting,
+                kind: Acting(subscription),
                 shared,
             },
             InnerEvent::ActionApplied(generation),
         ) if shared.generation == generation => {
-            let timer = start_quiescence_timer(
+            let timer = start_quiescence_timer_from_subscription(
                 &shared,
-                &context,
                 &context.inner_events_sender,
+                subscription,
             );
             InnerState {
                 kind: Running(timer),
@@ -1230,13 +1233,22 @@ fn start_quiescence_timer(
     context: &BrowserContext,
     inner_events_sender: &Sender<InnerEvent>,
 ) -> quiescence::QuiescenceTimer {
-    let activity: activity::ActivityStream =
-        context.screencast_activity.stream();
-    let (timer, quiescent) = quiescence::start(
-        QUIESCENCE_INITIAL_IDLE,
-        QUIESCENCE_TIMEOUT,
-        activity,
-    );
+    let subscription =
+        quiescence::subscribe(context.screencast_activity.stream());
+    start_quiescence_timer_from_subscription(
+        shared,
+        inner_events_sender,
+        subscription,
+    )
+}
+
+fn start_quiescence_timer_from_subscription(
+    shared: &InnerStateShared,
+    inner_events_sender: &Sender<InnerEvent>,
+    subscription: quiescence::QuiescenceSubscription,
+) -> quiescence::QuiescenceTimer {
+    let (timer, quiescent) =
+        subscription.start(QUIESCENCE_INITIAL_IDLE, QUIESCENCE_TIMEOUT);
     let generation = shared.generation;
     let sender = inner_events_sender.clone();
     spawn(async move {
@@ -1275,31 +1287,37 @@ async fn capture_browser_state(
         }
     };
 
-    log::debug!("taking screenshot before pause");
-    let format = ScreenshotFormat::Webp;
-    let screenshot_result = tokio::time::timeout(
-        Duration::from_secs(2),
-        context.page.screenshot(
-            ScreenshotParams::builder()
-                .omit_background(true)
-                .format(format)
-                .build(),
-        ),
-    )
-    .await;
+    // log::debug!("taking screenshot before pause");
+    // let format = ScreenshotFormat::Webp;
+    // let screenshot_result = tokio::time::timeout(
+    //     Duration::from_secs(2),
+    //     context.page.screenshot(
+    //         ScreenshotParams::builder()
+    //             .omit_background(true)
+    //             .format(format)
+    //             .build(),
+    //     ),
+    // )
+    // .await;
 
-    let screenshot = match screenshot_result {
-        Ok(Ok(data)) => Screenshot { data, format },
-        Ok(Err(error)) => {
-            log::warn!("screenshot failed: {}, skipping state capture", error);
-            return Ok(retry_with_timer(state.shared, context));
-        }
-        Err(_) => {
-            log::warn!("screenshot timed out, skipping state capture");
-            return Ok(retry_with_timer(state.shared, context));
-        }
-    };
-    state.shared.screenshot = Some(screenshot);
+    // let screenshot = match screenshot_result {
+    //     Ok(Ok(data)) => Screenshot { data, format },
+    //     Ok(Err(error)) => {
+    //         log::warn!("screenshot failed: {}, skipping state capture", error);
+    //         return Ok(retry_with_timer(state.shared, context));
+    //     }
+    //     Err(_) => {
+    //         log::warn!("screenshot timed out, skipping state capture");
+    //         return Ok(retry_with_timer(state.shared, context));
+    //     }
+    // };
+    // state.shared.screenshot = Some(screenshot);
+
+    // Fake for now.
+    state.shared.screenshot = Some(Screenshot {
+        format: ScreenshotFormat::Webp,
+        data: vec![],
+    });
 
     let page = context.page.clone();
     spawn(async move {

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -1161,19 +1161,11 @@ async fn process_event(
                 log::debug!("ignoring stale NavigationTimedOut");
                 state
             } else if matches!(state.kind, Navigating { .. } | Loading) {
-                log::warn!(
-                    "navigation timed out during {:?}, resuming",
+                bail!(
+                    "navigation timed out after {:?} during {:?}",
+                    NAVIGATION_TIMEOUT,
                     &state.kind,
                 );
-                let timer = start_quiescence_timer(
-                    &state.shared,
-                    context,
-                    &context.inner_events_sender,
-                );
-                InnerState {
-                    kind: Running(timer),
-                    shared: state.shared,
-                }
             } else {
                 state
             }

--- a/lib/bombadil/src/browser.rs
+++ b/lib/bombadil/src/browser.rs
@@ -578,13 +578,13 @@ async fn inner_events(
                 let frame_id = frame_id.clone();
                 async move {
                     if nav.frame_id == frame_id {
-                        None
-                    } else {
                         Some(InnerEvent::FrameRequestedNavigation {
                             frame_id: nav.frame_id.clone(),
                             reason: nav.reason.clone(),
                             url: nav.url.clone(),
                         })
+                    } else {
+                        None
                     }
                 }
             }),

--- a/lib/bombadil/src/browser/activity.rs
+++ b/lib/bombadil/src/browser/activity.rs
@@ -24,7 +24,7 @@ const MAX_FRAME_BUMPS: u32 = 10;
 const NETWORK_BUMP: Duration = Duration::from_millis(100);
 
 /// How long a screencast frame extends the quiescence deadline.
-const FRAME_BUMP: Duration = Duration::from_millis(100);
+const FRAME_BUMP: Duration = Duration::from_millis(32);
 
 pub type ActivityStream = Pin<Box<dyn Stream<Item = Duration> + Send>>;
 

--- a/lib/bombadil/src/browser/activity.rs
+++ b/lib/bombadil/src/browser/activity.rs
@@ -78,38 +78,38 @@ impl NetworkActivity {
     }
 }
 
-/// A shared handle to screencast frame activity. Subscribes to
-/// `Page.screencastFrame` events once; each call to [`stream`]
-/// returns a fresh activity stream for a new quiescence window.
-pub struct ScreencastActivity {
-    sender: broadcast::Sender<()>,
-    page: Arc<Page>,
+/// Centralized screencast subscription. Starts `Page.startScreencast`
+/// once, listens for frames, acks them, decodes the image bytes, and
+/// rebroadcasts via a tokio broadcast channel. Both activity tracking
+/// and screenshot capture subscribe to this single source.
+pub struct Screencast {
+    sender: broadcast::Sender<Arc<Vec<u8>>>,
 }
 
-fn screencast_params() -> page::StartScreencastParams {
-    page::StartScreencastParams::builder()
-        .format(page::StartScreencastFormat::Jpeg)
-        .quality(50)
-        .max_width(800)
-        .max_height(600)
-        .build()
-}
+impl Screencast {
+    /// Start the screencast and begin listening for frames.
+    pub async fn start(
+        page: &Arc<Page>,
+        width: u16,
+        height: u16,
+    ) -> anyhow::Result<Self> {
+        page.execute(
+            page::StartScreencastParams::builder()
+                .format(page::StartScreencastFormat::Jpeg)
+                .quality(50)
+                .max_width(width)
+                .max_height(height)
+                .build(),
+        )
+        .await?;
 
-impl ScreencastActivity {
-    /// Start the screencast and subscribe to frame events on `page`.
-    pub async fn subscribe(page: &Arc<Page>) -> anyhow::Result<Self> {
-        page.execute(screencast_params()).await?;
-
-        let (sender, _) = broadcast::channel::<()>(256);
+        let (sender, _) = broadcast::channel::<Arc<Vec<u8>>>(16);
 
         let frames =
             page.event_listener::<page::EventScreencastFrame>().await?;
 
         let tx = sender.clone();
         let page_for_ack = page.clone();
-        let debug_dir = std::path::PathBuf::from("/tmp/bombadil-screencast");
-        let _ = std::fs::create_dir_all(&debug_dir);
-        let mut frame_counter = 0u64;
         tokio::spawn(async move {
             tokio::pin!(frames);
             log::debug!("screencast: listener started");
@@ -118,14 +118,15 @@ impl ScreencastActivity {
                     "screencast: frame received (session_id={})",
                     event.session_id
                 );
-                // Save frame to disk for debugging.
-                let path = debug_dir.join(format!("{:06}.jpg", frame_counter));
-                if let Ok(bytes) =
-                    base64::prelude::BASE64_STANDARD.decode(&event.data)
+                let bytes = match base64::prelude::BASE64_STANDARD
+                    .decode(&event.data)
                 {
-                    let _ = std::fs::write(&path, &bytes);
-                }
-                frame_counter += 1;
+                    Ok(b) => b,
+                    Err(e) => {
+                        log::warn!("screencast: decode failed: {}", e);
+                        continue;
+                    }
+                };
                 // Acknowledge so Chrome keeps sending frames.
                 match page_for_ack
                     .execute(page::ScreencastFrameAckParams::new(
@@ -136,44 +137,40 @@ impl ScreencastActivity {
                     Ok(_) => log::debug!("screencast: ack sent"),
                     Err(e) => log::warn!("screencast: ack failed: {}", e),
                 }
-                let _ = tx.send(());
+                let _ = tx.send(Arc::new(bytes));
             }
             log::debug!("screencast: listener ended");
         });
 
-        Ok(ScreencastActivity {
-            sender,
-            page: page.clone(),
-        })
+        Ok(Screencast { sender })
     }
 
-    /// Re-issue StartScreencast so Chrome resumes sending frames
-    /// (e.g. after a debugger pause/resume cycle).
-    pub async fn restart(&self) {
-        if let Err(e) = self.page.execute(screencast_params()).await {
-            log::warn!("screencast: restart failed: {}", e);
-        }
+    /// Subscribe to decoded frame bytes.
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<Vec<u8>>> {
+        self.sender.subscribe()
     }
+}
 
-    /// Stop the screencast so the renderer is free for other
-    /// operations (screenshots, debugger pause).
-    pub async fn stop(&self) {
-        if let Err(e) = self
-            .page
-            .execute(page::StopScreencastParams::default())
-            .await
-        {
-            log::warn!("screencast: stop failed: {}", e);
-        }
+/// Wraps a [`Screencast`] subscription as a quiescence activity
+/// stream. Each frame bumps the deadline, up to a maximum number
+/// of bumps per window to avoid infinite animations blocking
+/// quiescence.
+pub struct ScreencastActivity {
+    screencast: Arc<Screencast>,
+}
+
+impl ScreencastActivity {
+    pub fn new(screencast: Arc<Screencast>) -> Self {
+        ScreencastActivity { screencast }
     }
 
     pub fn stream(&self) -> ActivityStream {
-        let receiver = self.sender.subscribe();
+        let receiver = self.screencast.subscribe();
         let mut count = 0u32;
         Box::pin(
             tokio_stream::wrappers::BroadcastStream::new(receiver)
                 .filter_map(|result| async { result.ok() })
-                .filter_map(move |()| {
+                .filter_map(move |_| {
                     count += 1;
                     if count <= MAX_FRAME_BUMPS {
                         std::future::ready(Some(FRAME_BUMP))

--- a/lib/bombadil/src/browser/activity.rs
+++ b/lib/bombadil/src/browser/activity.rs
@@ -76,7 +76,7 @@ impl NetworkActivity {
 }
 
 pub struct Screencast {
-    sender: broadcast::Sender<Arc<Vec<u8>>>,
+    sender: broadcast::Sender<Arc<[u8]>>,
 }
 
 impl Screencast {
@@ -95,7 +95,7 @@ impl Screencast {
         )
         .await?;
 
-        let (sender, _) = broadcast::channel::<Arc<Vec<u8>>>(16);
+        let (sender, _) = broadcast::channel::<Arc<[u8]>>(16);
         let frames =
             page.event_listener::<page::EventScreencastFrame>().await?;
         let tx = sender.clone();
@@ -127,7 +127,7 @@ impl Screencast {
                     Ok(_) => log::debug!("screencast: ack sent"),
                     Err(e) => log::warn!("screencast: ack failed: {}", e),
                 }
-                let _ = tx.send(Arc::new(bytes));
+                let _ = tx.send(Arc::from(bytes));
             }
             log::debug!("screencast: listener ended");
         });
@@ -135,7 +135,7 @@ impl Screencast {
         Ok(Screencast { sender })
     }
 
-    pub fn subscribe(&self) -> broadcast::Receiver<Arc<Vec<u8>>> {
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<[u8]>> {
         self.sender.subscribe()
     }
 }

--- a/lib/bombadil/src/browser/activity.rs
+++ b/lib/bombadil/src/browser/activity.rs
@@ -1,0 +1,84 @@
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use chromiumoxide::cdp::browser_protocol::network;
+use chromiumoxide::Page;
+use futures::{Stream, StreamExt, stream};
+use tokio::sync::broadcast;
+
+/// Maximum number of times a single URL can trigger activity before
+/// it is considered background noise and filtered out.
+const MAX_HITS_PER_URL: u32 = 3;
+
+pub type ActivityStream = Pin<Box<dyn Stream<Item = ()> + Send>>;
+
+/// A shared handle to network activity on a page.  Subscribes to CDP
+/// network events once; each call to [`stream`] returns a fresh,
+/// per-URL-deduplicated activity stream for a new quiescence window.
+pub struct NetworkActivity {
+    sender: broadcast::Sender<String>,
+}
+
+impl NetworkActivity {
+    /// Subscribe to CDP network events on `page`.  The returned
+    /// handle is cheap to clone and lives for the browser session.
+    pub async fn subscribe(
+        page: &Arc<Page>,
+    ) -> anyhow::Result<Self> {
+        let (sender, _) = broadcast::channel::<String>(256);
+
+        let requests = page
+            .event_listener::<network::EventRequestWillBeSent>()
+            .await?
+            .map(|event| event.request.url.clone());
+
+        let responses = page
+            .event_listener::<network::EventResponseReceived>()
+            .await?
+            .map(|event| event.response.url.clone());
+
+        let merged = stream::select_all(vec![
+            Box::pin(requests)
+                as Pin<Box<dyn Stream<Item = String> + Send>>,
+            Box::pin(responses),
+        ]);
+
+        let tx = sender.clone();
+        tokio::spawn(async move {
+            tokio::pin!(merged);
+            while let Some(url) = merged.next().await {
+                let _ = tx.send(url);
+            }
+        });
+
+        Ok(NetworkActivity { sender })
+    }
+
+    /// Create a new deduplicated activity stream.  Each URL may
+    /// trigger at most [`MAX_HITS_PER_URL`] events before being
+    /// silenced.  The dedup state is local to this stream.
+    pub fn stream(&self) -> ActivityStream {
+        let receiver = self.sender.subscribe();
+        let urls = tokio_stream::wrappers::BroadcastStream::new(receiver)
+            .filter_map(|result| async { result.ok() });
+        Box::pin(limit_per_url(urls))
+    }
+}
+
+/// Filter a stream of URLs, emitting `()` for each URL that has not
+/// yet exceeded [`MAX_HITS_PER_URL`].
+fn limit_per_url(
+    urls: impl Stream<Item = String> + Send + 'static,
+) -> impl Stream<Item = ()> + Send + 'static {
+    let mut counts: HashMap<String, u32> = HashMap::new();
+    urls.filter_map(move |url| {
+        let count = counts.entry(url).or_insert(0);
+        *count += 1;
+        if *count <= MAX_HITS_PER_URL {
+            std::future::ready(Some(()))
+        } else {
+            std::future::ready(None)
+        }
+    })
+}

--- a/lib/bombadil/src/browser/activity.rs
+++ b/lib/bombadil/src/browser/activity.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Result;
 use base64::Engine;
 use chromiumoxide::Page;
 use chromiumoxide::cdp::browser_protocol::network;
@@ -14,31 +15,26 @@ use tokio::sync::broadcast;
 /// it is considered background noise and filtered out.
 const MAX_HITS_PER_URL: u32 = 3;
 
+/// How long a network event extends the quiescence deadline.
+const NETWORK_BUMP: Duration = Duration::from_millis(100);
+
 /// Maximum number of screencast frames that can bump the quiescence
 /// timer in a single window. Prevents perpetual animations (CSS
 /// transitions, blinking cursors, etc.) from blocking quiescence
 /// indefinitely.
-const MAX_FRAME_BUMPS: u32 = 10;
-
-/// How long a network event extends the quiescence deadline.
-const NETWORK_BUMP: Duration = Duration::from_millis(100);
+const FRAME_BUMP_COUNT_MAX: u32 = 10;
 
 /// How long a screencast frame extends the quiescence deadline.
 const FRAME_BUMP: Duration = Duration::from_millis(32);
 
 pub type ActivityStream = Pin<Box<dyn Stream<Item = Duration> + Send>>;
 
-/// A shared handle to network activity on a page.  Subscribes to CDP
-/// network events once; each call to [`stream`] returns a fresh,
-/// per-URL-deduplicated activity stream for a new quiescence window.
 pub struct NetworkActivity {
     sender: broadcast::Sender<String>,
 }
 
 impl NetworkActivity {
-    /// Subscribe to CDP network events on `page`.  The returned
-    /// handle is cheap to clone and lives for the browser session.
-    pub async fn subscribe(page: &Arc<Page>) -> anyhow::Result<Self> {
+    pub async fn subscribe(page: &Arc<Page>) -> Result<Self> {
         let (sender, _) = broadcast::channel::<String>(256);
 
         let requests = page
@@ -67,9 +63,6 @@ impl NetworkActivity {
         Ok(NetworkActivity { sender })
     }
 
-    /// Create a new deduplicated activity stream.  Each URL may
-    /// trigger at most [`MAX_HITS_PER_URL`] events before being
-    /// silenced.  The dedup state is local to this stream.
     pub fn stream(&self) -> ActivityStream {
         let receiver = self.sender.subscribe();
         let urls = tokio_stream::wrappers::BroadcastStream::new(receiver)
@@ -78,21 +71,16 @@ impl NetworkActivity {
     }
 }
 
-/// Centralized screencast subscription. Starts `Page.startScreencast`
-/// once, listens for frames, acks them, decodes the image bytes, and
-/// rebroadcasts via a tokio broadcast channel. Both activity tracking
-/// and screenshot capture subscribe to this single source.
 pub struct Screencast {
     sender: broadcast::Sender<Arc<Vec<u8>>>,
 }
 
 impl Screencast {
-    /// Start the screencast and begin listening for frames.
     pub async fn start(
         page: &Arc<Page>,
         width: u16,
         height: u16,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self> {
         page.execute(
             page::StartScreencastParams::builder()
                 .format(page::StartScreencastFormat::Jpeg)
@@ -104,12 +92,11 @@ impl Screencast {
         .await?;
 
         let (sender, _) = broadcast::channel::<Arc<Vec<u8>>>(16);
-
         let frames =
             page.event_listener::<page::EventScreencastFrame>().await?;
-
         let tx = sender.clone();
-        let page_for_ack = page.clone();
+        let page = page.clone();
+
         tokio::spawn(async move {
             tokio::pin!(frames);
             log::debug!("screencast: listener started");
@@ -127,8 +114,7 @@ impl Screencast {
                         continue;
                     }
                 };
-                // Acknowledge so Chrome keeps sending frames.
-                match page_for_ack
+                match page
                     .execute(page::ScreencastFrameAckParams::new(
                         event.session_id,
                     ))
@@ -145,16 +131,11 @@ impl Screencast {
         Ok(Screencast { sender })
     }
 
-    /// Subscribe to decoded frame bytes.
     pub fn subscribe(&self) -> broadcast::Receiver<Arc<Vec<u8>>> {
         self.sender.subscribe()
     }
 }
 
-/// Wraps a [`Screencast`] subscription as a quiescence activity
-/// stream. Each frame bumps the deadline, up to a maximum number
-/// of bumps per window to avoid infinite animations blocking
-/// quiescence.
 pub struct ScreencastActivity {
     screencast: Arc<Screencast>,
 }
@@ -172,7 +153,7 @@ impl ScreencastActivity {
                 .filter_map(|result| async { result.ok() })
                 .filter_map(move |_| {
                     count += 1;
-                    if count <= MAX_FRAME_BUMPS {
+                    if count <= FRAME_BUMP_COUNT_MAX {
                         std::future::ready(Some(FRAME_BUMP))
                     } else {
                         std::future::ready(None)
@@ -182,8 +163,6 @@ impl ScreencastActivity {
     }
 }
 
-/// Filter a stream of URLs, emitting [`NETWORK_BUMP`] for each URL
-/// that has not yet exceeded [`MAX_HITS_PER_URL`].
 fn limit_per_url(
     urls: impl Stream<Item = String> + Send + 'static,
 ) -> impl Stream<Item = Duration> + Send + 'static {

--- a/lib/bombadil/src/browser/activity.rs
+++ b/lib/bombadil/src/browser/activity.rs
@@ -15,8 +15,11 @@ use tokio::sync::broadcast;
 /// it is considered background noise and filtered out.
 const MAX_HITS_PER_URL: u32 = 3;
 
-/// How long a network event extends the quiescence deadline.
-const NETWORK_BUMP: Duration = Duration::from_millis(100);
+/// How long a new outgoing request extends the quiescence deadline.
+const NETWORK_BUMP_REQUEST: Duration = Duration::from_millis(100);
+
+/// How long an incoming response extends the quiescence deadline.
+const NETWORK_BUMP_RESPONSE: Duration = Duration::from_millis(10);
 
 /// Maximum number of screencast frames that can bump the quiescence
 /// timer in a single window. Prevents perpetual animations (CSS
@@ -30,33 +33,34 @@ const FRAME_BUMP: Duration = Duration::from_millis(32);
 pub type ActivityStream = Pin<Box<dyn Stream<Item = Duration> + Send>>;
 
 pub struct NetworkActivity {
-    sender: broadcast::Sender<String>,
+    sender: broadcast::Sender<(String, Duration)>,
 }
 
 impl NetworkActivity {
     pub async fn subscribe(page: &Arc<Page>) -> Result<Self> {
-        let (sender, _) = broadcast::channel::<String>(256);
+        let (sender, _) = broadcast::channel::<(String, Duration)>(256);
 
         let requests = page
             .event_listener::<network::EventRequestWillBeSent>()
             .await?
-            .map(|event| event.request.url.clone());
+            .map(|event| (event.request.url.clone(), NETWORK_BUMP_REQUEST));
 
         let responses = page
             .event_listener::<network::EventResponseReceived>()
             .await?
-            .map(|event| event.response.url.clone());
+            .map(|event| (event.response.url.clone(), NETWORK_BUMP_RESPONSE));
 
         let merged = stream::select_all(vec![
-            Box::pin(requests) as Pin<Box<dyn Stream<Item = String> + Send>>,
+            Box::pin(requests)
+                as Pin<Box<dyn Stream<Item = (String, Duration)> + Send>>,
             Box::pin(responses),
         ]);
 
         let tx = sender.clone();
         tokio::spawn(async move {
             tokio::pin!(merged);
-            while let Some(url) = merged.next().await {
-                let _ = tx.send(url);
+            while let Some(pair) = merged.next().await {
+                let _ = tx.send(pair);
             }
         });
 
@@ -65,9 +69,9 @@ impl NetworkActivity {
 
     pub fn stream(&self) -> ActivityStream {
         let receiver = self.sender.subscribe();
-        let urls = tokio_stream::wrappers::BroadcastStream::new(receiver)
+        let events = tokio_stream::wrappers::BroadcastStream::new(receiver)
             .filter_map(|result| async { result.ok() });
-        Box::pin(limit_per_url(urls))
+        Box::pin(limit_per_url(events))
     }
 }
 
@@ -164,14 +168,14 @@ impl ScreencastActivity {
 }
 
 fn limit_per_url(
-    urls: impl Stream<Item = String> + Send + 'static,
+    events: impl Stream<Item = (String, Duration)> + Send + 'static,
 ) -> impl Stream<Item = Duration> + Send + 'static {
     let mut counts: HashMap<String, u32> = HashMap::new();
-    urls.filter_map(move |url| {
+    events.filter_map(move |(url, bump)| {
         let count = counts.entry(url).or_insert(0);
         *count += 1;
         if *count <= MAX_HITS_PER_URL {
-            std::future::ready(Some(NETWORK_BUMP))
+            std::future::ready(Some(bump))
         } else {
             std::future::ready(None)
         }

--- a/lib/bombadil/src/browser/activity.rs
+++ b/lib/bombadil/src/browser/activity.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use base64::Engine;
 use chromiumoxide::Page;
 use chromiumoxide::cdp::browser_protocol::network;
 use chromiumoxide::cdp::browser_protocol::page;
@@ -23,10 +24,7 @@ const MAX_FRAME_BUMPS: u32 = 10;
 const NETWORK_BUMP: Duration = Duration::from_millis(100);
 
 /// How long a screencast frame extends the quiescence deadline.
-/// Just over one frame interval at 60fps (~16.6ms) so that a
-/// subsequent frame arriving on time resets the deadline, but a
-/// single missed frame means the page has stopped painting.
-const FRAME_BUMP: Duration = Duration::from_millis(34);
+const FRAME_BUMP: Duration = Duration::from_millis(100);
 
 pub type ActivityStream = Pin<Box<dyn Stream<Item = Duration> + Send>>;
 
@@ -85,20 +83,22 @@ impl NetworkActivity {
 /// returns a fresh activity stream for a new quiescence window.
 pub struct ScreencastActivity {
     sender: broadcast::Sender<()>,
+    page: Arc<Page>,
+}
+
+fn screencast_params() -> page::StartScreencastParams {
+    page::StartScreencastParams::builder()
+        .format(page::StartScreencastFormat::Jpeg)
+        .quality(50)
+        .max_width(800)
+        .max_height(600)
+        .build()
 }
 
 impl ScreencastActivity {
     /// Start the screencast and subscribe to frame events on `page`.
     pub async fn subscribe(page: &Arc<Page>) -> anyhow::Result<Self> {
-        page.execute(
-            page::StartScreencastParams::builder()
-                .format(page::StartScreencastFormat::Jpeg)
-                .quality(1)
-                .max_width(1)
-                .max_height(1)
-                .build(),
-        )
-        .await?;
+        page.execute(screencast_params()).await?;
 
         let (sender, _) = broadcast::channel::<()>(256);
 
@@ -106,21 +106,53 @@ impl ScreencastActivity {
             page.event_listener::<page::EventScreencastFrame>().await?;
 
         let tx = sender.clone();
-        let page = page.clone();
+        let page_for_ack = page.clone();
+        let debug_dir = std::path::PathBuf::from("/tmp/bombadil-screencast");
+        let _ = std::fs::create_dir_all(&debug_dir);
+        let mut frame_counter = 0u64;
         tokio::spawn(async move {
             tokio::pin!(frames);
+            log::debug!("screencast: listener started");
             while let Some(event) = frames.next().await {
+                log::debug!(
+                    "screencast: frame received (session_id={})",
+                    event.session_id
+                );
+                // Save frame to disk for debugging.
+                let path = debug_dir.join(format!("{:06}.jpg", frame_counter));
+                if let Ok(bytes) =
+                    base64::prelude::BASE64_STANDARD.decode(&event.data)
+                {
+                    let _ = std::fs::write(&path, &bytes);
+                }
+                frame_counter += 1;
                 // Acknowledge so Chrome keeps sending frames.
-                let _ = page
+                match page_for_ack
                     .execute(page::ScreencastFrameAckParams::new(
                         event.session_id,
                     ))
-                    .await;
+                    .await
+                {
+                    Ok(_) => log::debug!("screencast: ack sent"),
+                    Err(e) => log::warn!("screencast: ack failed: {}", e),
+                }
                 let _ = tx.send(());
             }
+            log::debug!("screencast: listener ended");
         });
 
-        Ok(ScreencastActivity { sender })
+        Ok(ScreencastActivity {
+            sender,
+            page: page.clone(),
+        })
+    }
+
+    /// Re-issue StartScreencast so Chrome resumes sending frames
+    /// (e.g. after a debugger pause/resume cycle).
+    pub async fn restart(&self) {
+        if let Err(e) = self.page.execute(screencast_params()).await {
+            log::warn!("screencast: restart failed: {}", e);
+        }
     }
 
     pub fn stream(&self) -> ActivityStream {

--- a/lib/bombadil/src/browser/activity.rs
+++ b/lib/bombadil/src/browser/activity.rs
@@ -155,6 +155,18 @@ impl ScreencastActivity {
         }
     }
 
+    /// Stop the screencast so the renderer is free for other
+    /// operations (screenshots, debugger pause).
+    pub async fn stop(&self) {
+        if let Err(e) = self
+            .page
+            .execute(page::StopScreencastParams::default())
+            .await
+        {
+            log::warn!("screencast: stop failed: {}", e);
+        }
+    }
+
     pub fn stream(&self) -> ActivityStream {
         let receiver = self.sender.subscribe();
         let mut count = 0u32;

--- a/lib/bombadil/src/browser/quiescence.rs
+++ b/lib/bombadil/src/browser/quiescence.rs
@@ -51,8 +51,10 @@ impl QuiescenceSubscription {
         self,
         timeout_idle: Duration,
         timeout_max: Duration,
-    ) -> (QuiescenceTimer, impl std::future::Future<Output = bool> + Send)
-    {
+    ) -> (
+        QuiescenceTimer,
+        impl std::future::Future<Output = bool> + Send,
+    ) {
         let waiter = QuiescenceWaiter {
             cancel: self.cancel_receiver,
             activity: self.activity,
@@ -73,7 +75,10 @@ pub fn start(
     timeout_idle: Duration,
     timeout_max: Duration,
     activity: Pin<Box<dyn Stream<Item = Duration> + Send>>,
-) -> (QuiescenceTimer, impl std::future::Future<Output = bool> + Send) {
+) -> (
+    QuiescenceTimer,
+    impl std::future::Future<Output = bool> + Send,
+) {
     subscribe(activity).start(timeout_idle, timeout_max)
 }
 
@@ -145,11 +150,8 @@ mod tests {
             }
         }));
 
-        let (_timer, wait) = start(
-            Duration::from_millis(150),
-            Duration::from_secs(5),
-            activity,
-        );
+        let (_timer, wait) =
+            start(Duration::from_millis(150), Duration::from_secs(5), activity);
         let t = Instant::now();
         assert!(wait.await);
         let elapsed = t.elapsed();

--- a/lib/bombadil/src/browser/quiescence.rs
+++ b/lib/bombadil/src/browser/quiescence.rs
@@ -15,8 +15,8 @@ pub struct QuiescenceSubscription {
 
 /// A handle representing an active quiescence timer.
 ///
-/// Held by the state machine to keep the timer alive. When dropped,
-/// the corresponding waiter resolves as cancelled (not quiescent).
+/// Keeps the timer alive. When dropped, the corresponding waiter resolves as
+/// cancelled (not quiescent).
 pub struct QuiescenceTimer {
     _cancel: tokio::sync::oneshot::Sender<()>,
 }
@@ -70,25 +70,13 @@ impl QuiescenceSubscription {
     }
 }
 
-/// Convenience: subscribe and start in one step.
-pub fn start(
-    timeout_idle: Duration,
-    timeout_max: Duration,
-    activity: Pin<Box<dyn Stream<Item = Duration> + Send>>,
-) -> (
-    QuiescenceTimer,
-    impl std::future::Future<Output = bool> + Send,
-) {
-    subscribe(activity).start(timeout_idle, timeout_max)
-}
-
 impl QuiescenceWaiter {
     async fn wait(mut self) -> bool {
-        let deadline = Instant::now() + self.timeout_max;
+        let deadline_max = Instant::now() + self.timeout_max;
         let mut deadline_idle = Instant::now() + self.timeout_idle;
 
         loop {
-            let next = deadline_idle.min(deadline);
+            let next = deadline_idle.min(deadline_max);
             tokio::select! {
                 _ = sleep_until(next) => {
                     return true;
@@ -101,7 +89,7 @@ impl QuiescenceWaiter {
                         Some(bump) => {
                             deadline_idle =
                                 (Instant::now() + bump)
-                                    .min(deadline);
+                                    .min(deadline_max);
                         }
                         None => {
                             self.activity =
@@ -120,13 +108,24 @@ mod tests {
     use futures::stream;
     use tokio::time::Instant;
 
+    pub fn start_immediately(
+        timeout_idle: Duration,
+        timeout_max: Duration,
+        activity: Pin<Box<dyn Stream<Item = Duration> + Send>>,
+    ) -> (
+        QuiescenceTimer,
+        impl std::future::Future<Output = bool> + Send,
+    ) {
+        subscribe(activity).start(timeout_idle, timeout_max)
+    }
+
     fn empty_activity() -> Pin<Box<dyn Stream<Item = Duration> + Send>> {
         Box::pin(stream::empty())
     }
 
     #[tokio::test]
     async fn fires_after_timeout_idle_with_no_activity() {
-        let (_timer, wait) = start(
+        let (_timer, wait) = start_immediately(
             Duration::from_millis(100),
             Duration::from_secs(5),
             empty_activity(),
@@ -150,8 +149,11 @@ mod tests {
             }
         }));
 
-        let (_timer, wait) =
-            start(Duration::from_millis(150), Duration::from_secs(5), activity);
+        let (_timer, wait) = start_immediately(
+            Duration::from_millis(150),
+            Duration::from_secs(5),
+            activity,
+        );
         let t = Instant::now();
         assert!(wait.await);
         let elapsed = t.elapsed();
@@ -166,7 +168,7 @@ mod tests {
             Some((bump, ()))
         }));
 
-        let (_timer, wait) = start(
+        let (_timer, wait) = start_immediately(
             Duration::from_millis(100),
             Duration::from_millis(300),
             activity,
@@ -180,7 +182,7 @@ mod tests {
 
     #[tokio::test]
     async fn drop_handle_cancels() {
-        let (timer, wait) = start(
+        let (timer, wait) = start_immediately(
             Duration::from_secs(10),
             Duration::from_secs(10),
             empty_activity(),

--- a/lib/bombadil/src/browser/quiescence.rs
+++ b/lib/bombadil/src/browser/quiescence.rs
@@ -1,0 +1,153 @@
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::time::{Instant, sleep_until};
+
+/// A timer that waits for a burst of activity to settle.
+///
+/// Each call to [`bump`] resets a short idle countdown. The timer
+/// resolves when either:
+/// - the idle timeout expires (no bump received for `timeout_idle`), or
+/// - the max timeout fires regardless of activity.
+pub struct QuiescenceTimer {
+    sender: mpsc::Sender<()>,
+}
+
+pub struct QuiescenceWaiter {
+    receiver: mpsc::Receiver<()>,
+    timeout_idle: Duration,
+    timeout_max: Duration,
+}
+
+impl QuiescenceTimer {
+    pub fn new(
+        timeout_idle: Duration,
+        timeout_max: Duration,
+    ) -> (Self, QuiescenceWaiter) {
+        let (sender, receiver) = mpsc::channel(64);
+        (
+            QuiescenceTimer { sender },
+            QuiescenceWaiter {
+                receiver,
+                timeout_idle,
+                timeout_max,
+            },
+        )
+    }
+
+    /// Signal that activity occurred, resetting the idle countdown.
+    pub fn bump(&self) {
+        // Best-effort: if the channel is full or closed, ignore.
+        let _ = self.sender.try_send(());
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.sender.is_closed()
+    }
+}
+
+impl QuiescenceWaiter {
+    /// Wait until the browser is quiescent (idle timeout elapsed) or
+    /// the max timeout fires, whichever comes first.
+    pub async fn wait(mut self) {
+        let deadline = Instant::now() + self.timeout_max;
+        let mut deadline_idle = Instant::now() + self.timeout_idle;
+
+        loop {
+            let next = deadline_idle.min(deadline);
+            tokio::select! {
+                _ = sleep_until(next) => {
+                    break;
+                }
+                bump = self.receiver.recv() => {
+                    match bump {
+                        Some(()) => {
+                            deadline_idle =
+                                (Instant::now() + self.timeout_idle)
+                                    .min(deadline);
+                        }
+                        // Sender dropped — treat as quiescent.
+                        None => break,
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant as StdInstant;
+
+    #[tokio::test]
+    async fn fires_after_timeout_idle_with_no_bumps() {
+        let (_timer, waiter) = QuiescenceTimer::new(
+            Duration::from_millis(100),
+            Duration::from_secs(5),
+        );
+        let start = StdInstant::now();
+        waiter.wait().await;
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(80));
+        assert!(elapsed < Duration::from_millis(500));
+    }
+
+    #[tokio::test]
+    async fn bumps_extend_timeout_idle() {
+        let (timer, waiter) = QuiescenceTimer::new(
+            Duration::from_millis(150),
+            Duration::from_secs(5),
+        );
+        let start = StdInstant::now();
+
+        tokio::spawn(async move {
+            for _ in 0..5 {
+                tokio::time::sleep(Duration::from_millis(80)).await;
+                timer.bump();
+            }
+        });
+
+        waiter.wait().await;
+        let elapsed = start.elapsed();
+        // 5 bumps at 80ms intervals = ~400ms of activity, then
+        // 150ms idle
+        assert!(elapsed >= Duration::from_millis(400));
+    }
+
+    #[tokio::test]
+    async fn timeout_max_caps_wait() {
+        let (timer, waiter) = QuiescenceTimer::new(
+            Duration::from_millis(100),
+            Duration::from_millis(300),
+        );
+        let start = StdInstant::now();
+
+        // Bump continuously — should still finish at max timeout.
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                if timer.is_closed() {
+                    break;
+                }
+                timer.bump();
+            }
+        });
+
+        waiter.wait().await;
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(250));
+        assert!(elapsed < Duration::from_millis(600));
+    }
+
+    #[tokio::test]
+    async fn sender_drop_resolves_immediately() {
+        let (timer, waiter) = QuiescenceTimer::new(
+            Duration::from_secs(10),
+            Duration::from_secs(10),
+        );
+        drop(timer);
+        let start = StdInstant::now();
+        waiter.wait().await;
+        assert!(start.elapsed() < Duration::from_millis(100));
+    }
+}

--- a/lib/bombadil/src/browser/quiescence.rs
+++ b/lib/bombadil/src/browser/quiescence.rs
@@ -4,6 +4,15 @@ use std::time::Duration;
 use futures::{Stream, StreamExt};
 use tokio::time::{Instant, sleep_until};
 
+/// A subscription that buffers activity signals before the countdown
+/// begins. Call [`start`](QuiescenceSubscription::start) to begin
+/// the actual timer.
+pub struct QuiescenceSubscription {
+    cancel_sender: tokio::sync::oneshot::Sender<()>,
+    cancel_receiver: tokio::sync::oneshot::Receiver<()>,
+    activity: Pin<Box<dyn Stream<Item = Duration> + Send>>,
+}
+
 /// A handle representing an active quiescence timer.
 ///
 /// Held by the state machine to keep the timer alive. When dropped,
@@ -19,34 +28,53 @@ struct QuiescenceWaiter {
     timeout_max: Duration,
 }
 
-/// Create a quiescence timer driven by an activity stream.
+/// Begin buffering activity signals without starting the countdown.
 ///
-/// Each item in the stream is a [`Duration`] that bumps the idle
-/// deadline by that amount from now, allowing different activity
-/// sources (network, screencast frames, etc.) to control their own
-/// settling delay.
-///
-/// Returns a handle and a future. The future resolves with `true`
-/// when the system is quiescent (idle timeout or max timeout
-/// elapsed), or `false` if the handle was dropped (cancelled).
+/// The returned [`QuiescenceSubscription`] holds the activity stream
+/// so that signals arriving before [`QuiescenceSubscription::start`]
+/// are not lost.
+pub fn subscribe(
+    activity: Pin<Box<dyn Stream<Item = Duration> + Send>>,
+) -> QuiescenceSubscription {
+    let (cancel_sender, cancel_receiver) = tokio::sync::oneshot::channel();
+    QuiescenceSubscription {
+        cancel_sender,
+        cancel_receiver,
+        activity,
+    }
+}
+
+impl QuiescenceSubscription {
+    /// Start the countdown. Returns a timer handle and a future that
+    /// resolves with `true` when quiescent, or `false` if cancelled.
+    pub fn start(
+        self,
+        timeout_idle: Duration,
+        timeout_max: Duration,
+    ) -> (QuiescenceTimer, impl std::future::Future<Output = bool> + Send)
+    {
+        let waiter = QuiescenceWaiter {
+            cancel: self.cancel_receiver,
+            activity: self.activity,
+            timeout_idle,
+            timeout_max,
+        };
+        (
+            QuiescenceTimer {
+                _cancel: self.cancel_sender,
+            },
+            waiter.wait(),
+        )
+    }
+}
+
+/// Convenience: subscribe and start in one step.
 pub fn start(
     timeout_idle: Duration,
     timeout_max: Duration,
     activity: Pin<Box<dyn Stream<Item = Duration> + Send>>,
 ) -> (QuiescenceTimer, impl std::future::Future<Output = bool> + Send) {
-    let (cancel_sender, cancel_receiver) = tokio::sync::oneshot::channel();
-    let waiter = QuiescenceWaiter {
-        cancel: cancel_receiver,
-        activity,
-        timeout_idle,
-        timeout_max,
-    };
-    (
-        QuiescenceTimer {
-            _cancel: cancel_sender,
-        },
-        waiter.wait(),
-    )
+    subscribe(activity).start(timeout_idle, timeout_max)
 }
 
 impl QuiescenceWaiter {

--- a/lib/bombadil/src/browser/quiescence.rs
+++ b/lib/bombadil/src/browser/quiescence.rs
@@ -1,54 +1,51 @@
+use std::pin::Pin;
 use std::time::Duration;
-use tokio::sync::mpsc;
+
+use futures::{Stream, StreamExt};
 use tokio::time::{Instant, sleep_until};
 
-/// A timer that waits for a burst of activity to settle.
+/// A handle representing an active quiescence timer.
 ///
-/// Each call to [`bump`] resets a short idle countdown. The timer
-/// resolves when either:
-/// - the idle timeout expires (no bump received for `timeout_idle`), or
-/// - the max timeout fires regardless of activity.
+/// Held by the state machine to keep the timer alive. When dropped,
+/// the corresponding waiter resolves as cancelled (not quiescent).
 pub struct QuiescenceTimer {
-    sender: mpsc::Sender<()>,
+    _cancel: tokio::sync::oneshot::Sender<()>,
 }
 
-pub struct QuiescenceWaiter {
-    receiver: mpsc::Receiver<()>,
+struct QuiescenceWaiter {
+    cancel: tokio::sync::oneshot::Receiver<()>,
+    activity: Pin<Box<dyn Stream<Item = ()> + Send>>,
     timeout_idle: Duration,
     timeout_max: Duration,
 }
 
-impl QuiescenceTimer {
-    pub fn new(
-        timeout_idle: Duration,
-        timeout_max: Duration,
-    ) -> (Self, QuiescenceWaiter) {
-        let (sender, receiver) = mpsc::channel(64);
-        (
-            QuiescenceTimer { sender },
-            QuiescenceWaiter {
-                receiver,
-                timeout_idle,
-                timeout_max,
-            },
-        )
-    }
-
-    /// Signal that activity occurred, resetting the idle countdown.
-    pub fn bump(&self) {
-        // Best-effort: if the channel is full or closed, ignore.
-        let _ = self.sender.try_send(());
-    }
-
-    pub fn is_closed(&self) -> bool {
-        self.sender.is_closed()
-    }
+/// Create a quiescence timer driven by an activity stream.
+///
+/// Returns a handle and a future. The future resolves with `true`
+/// when the system is quiescent (idle timeout or max timeout
+/// elapsed), or `false` if the handle was dropped (cancelled).
+pub fn start(
+    timeout_idle: Duration,
+    timeout_max: Duration,
+    activity: Pin<Box<dyn Stream<Item = ()> + Send>>,
+) -> (QuiescenceTimer, impl std::future::Future<Output = bool> + Send) {
+    let (cancel_sender, cancel_receiver) = tokio::sync::oneshot::channel();
+    let waiter = QuiescenceWaiter {
+        cancel: cancel_receiver,
+        activity,
+        timeout_idle,
+        timeout_max,
+    };
+    (
+        QuiescenceTimer {
+            _cancel: cancel_sender,
+        },
+        waiter.wait(),
+    )
 }
 
 impl QuiescenceWaiter {
-    /// Wait until the browser is quiescent (idle timeout elapsed) or
-    /// the max timeout fires, whichever comes first.
-    pub async fn wait(mut self) {
+    async fn wait(mut self) -> bool {
         let deadline = Instant::now() + self.timeout_max;
         let mut deadline_idle = Instant::now() + self.timeout_idle;
 
@@ -56,17 +53,22 @@ impl QuiescenceWaiter {
             let next = deadline_idle.min(deadline);
             tokio::select! {
                 _ = sleep_until(next) => {
-                    break;
+                    return true;
                 }
-                bump = self.receiver.recv() => {
-                    match bump {
+                _ = &mut self.cancel => {
+                    return false;
+                }
+                event = self.activity.next() => {
+                    match event {
                         Some(()) => {
                             deadline_idle =
                                 (Instant::now() + self.timeout_idle)
                                     .min(deadline);
                         }
-                        // Sender dropped — treat as quiescent.
-                        None => break,
+                        None => {
+                            self.activity =
+                                Box::pin(futures::stream::pending());
+                        }
                     }
                 }
             }
@@ -77,77 +79,78 @@ impl QuiescenceWaiter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Instant as StdInstant;
+    use futures::stream;
+    use tokio::time::Instant;
+
+    fn empty_activity() -> Pin<Box<dyn Stream<Item = ()> + Send>> {
+        Box::pin(stream::empty())
+    }
 
     #[tokio::test]
-    async fn fires_after_timeout_idle_with_no_bumps() {
-        let (_timer, waiter) = QuiescenceTimer::new(
+    async fn fires_after_timeout_idle_with_no_activity() {
+        let (_timer, wait) = start(
             Duration::from_millis(100),
             Duration::from_secs(5),
+            empty_activity(),
         );
-        let start = StdInstant::now();
-        waiter.wait().await;
-        let elapsed = start.elapsed();
+        let t = Instant::now();
+        assert!(wait.await);
+        let elapsed = t.elapsed();
         assert!(elapsed >= Duration::from_millis(80));
         assert!(elapsed < Duration::from_millis(500));
     }
 
     #[tokio::test]
-    async fn bumps_extend_timeout_idle() {
-        let (timer, waiter) = QuiescenceTimer::new(
+    async fn stream_activity_extends_idle() {
+        let activity = Box::pin(stream::unfold(0u32, |i| async move {
+            if i < 5 {
+                tokio::time::sleep(Duration::from_millis(80)).await;
+                Some(((), i + 1))
+            } else {
+                None
+            }
+        }));
+
+        let (_timer, wait) = start(
             Duration::from_millis(150),
             Duration::from_secs(5),
+            activity,
         );
-        let start = StdInstant::now();
-
-        tokio::spawn(async move {
-            for _ in 0..5 {
-                tokio::time::sleep(Duration::from_millis(80)).await;
-                timer.bump();
-            }
-        });
-
-        waiter.wait().await;
-        let elapsed = start.elapsed();
-        // 5 bumps at 80ms intervals = ~400ms of activity, then
-        // 150ms idle
+        let t = Instant::now();
+        assert!(wait.await);
+        let elapsed = t.elapsed();
         assert!(elapsed >= Duration::from_millis(400));
     }
 
     #[tokio::test]
     async fn timeout_max_caps_wait() {
-        let (timer, waiter) = QuiescenceTimer::new(
+        let activity = Box::pin(stream::unfold((), |()| async {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            Some(((), ()))
+        }));
+
+        let (_timer, wait) = start(
             Duration::from_millis(100),
             Duration::from_millis(300),
+            activity,
         );
-        let start = StdInstant::now();
-
-        // Bump continuously — should still finish at max timeout.
-        tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(Duration::from_millis(20)).await;
-                if timer.is_closed() {
-                    break;
-                }
-                timer.bump();
-            }
-        });
-
-        waiter.wait().await;
-        let elapsed = start.elapsed();
+        let t = Instant::now();
+        assert!(wait.await);
+        let elapsed = t.elapsed();
         assert!(elapsed >= Duration::from_millis(250));
         assert!(elapsed < Duration::from_millis(600));
     }
 
     #[tokio::test]
-    async fn sender_drop_resolves_immediately() {
-        let (timer, waiter) = QuiescenceTimer::new(
+    async fn drop_handle_cancels() {
+        let (timer, wait) = start(
             Duration::from_secs(10),
             Duration::from_secs(10),
+            empty_activity(),
         );
         drop(timer);
-        let start = StdInstant::now();
-        waiter.wait().await;
-        assert!(start.elapsed() < Duration::from_millis(100));
+        let t = Instant::now();
+        assert!(!wait.await);
+        assert!(t.elapsed() < Duration::from_millis(100));
     }
 }

--- a/lib/bombadil/src/runner.rs
+++ b/lib/bombadil/src/runner.rs
@@ -13,7 +13,6 @@ use serde::Deserialize;
 use serde_json as json;
 use std::cmp::max;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::select;
 use tokio::signal::ctrl_c;
 
@@ -210,9 +209,8 @@ impl Runner {
 
                                 let action =
                                     action_tree.pick(&mut rand::rng())?.clone();
-                                let timeout = action_timeout(&action);
                                 log::info!("picked action: {:?}", action);
-                                browser.apply(action.clone(), timeout)?;
+                                browser.apply(action.clone())?;
                                 last_action = Some(action);
                             }
                             BrowserEvent::Error(error) => {
@@ -298,31 +296,6 @@ async fn run_extractors(
         .collect();
 
     Ok(results)
-}
-
-fn action_timeout(action: &BrowserAction) -> Duration {
-    match action {
-        BrowserAction::Back => Duration::from_secs(2),
-        BrowserAction::Forward => Duration::from_secs(2),
-        BrowserAction::Reload => Duration::from_secs(2),
-        BrowserAction::Click { .. } => Duration::from_millis(500),
-        BrowserAction::DoubleClick { delay_millis, .. } => {
-            Duration::from_millis(delay_millis.saturating_add(500))
-        }
-        BrowserAction::TypeText {
-            text, delay_millis, ..
-        } => {
-            // We'll wait for the text to be entered, and an extra 100ms.
-            let text_entry_millis =
-                (*delay_millis).saturating_mul(text.len() as u64);
-            Duration::from_millis(text_entry_millis.saturating_add(100u64))
-        }
-        BrowserAction::PressKey { .. } => Duration::from_millis(50),
-        BrowserAction::ScrollUp { .. } => Duration::from_millis(100),
-        BrowserAction::ScrollDown { .. } => Duration::from_millis(100),
-        BrowserAction::Wait => Duration::from_secs(1),
-        BrowserAction::SetFileInputFiles { .. } => Duration::from_millis(100),
-    }
 }
 
 fn log_coverage_stats_increment(coverage: &Coverage) {

--- a/lib/bombadil/src/specification/defaults.ts
+++ b/lib/bombadil/src/specification/defaults.ts
@@ -15,9 +15,9 @@ import {
 import { weighted } from "@antithesishq/bombadil/actions";
 
 export const defaultActions = weighted([
-  [10, clicks],
-  [10, inputs],
-  [5, scroll],
-  [1, navigation],
+  [100, clicks],
+  [100, inputs],
+  [50, scroll],
+  [10, navigation],
   [1, waitOnce],
 ]);

--- a/lib/integration-tests/tests/file-picker/index.html
+++ b/lib/integration-tests/tests/file-picker/index.html
@@ -1,9 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="UTF-8">
     <title>File Picker Test</title>
+    <style>
+        form {
+            display: flex;
+            flex-direction: column;
+        }
+    </style>
 </head>
+
 <body>
     <h1>File Picker Test</h1>
     <form id="upload-form">
@@ -28,4 +36,5 @@
         });
     </script>
 </body>
+
 </html>

--- a/lib/integration-tests/tests/integration_tests.rs
+++ b/lib/integration-tests/tests/integration_tests.rs
@@ -237,7 +237,7 @@ impl<'a> BrowserIntegrationTest<'a> {
                 emulation: Emulation {
                     width: 800,
                     height: 600,
-                    device_scale_factor: 2.0,
+                    device_scale_factor: 1.0,
                 },
                 instrumentation: Default::default(),
                 downloads_directory: downloads_directory.path().to_path_buf(),
@@ -489,7 +489,7 @@ async fn test_browser_lifecycle() {
             emulation: Emulation {
                 width: 800,
                 height: 600,
-                device_scale_factor: 2.0,
+                device_scale_factor: 1.0,
             },
             instrumentation: Default::default(),
             downloads_directory: downloads_directory.path().to_path_buf(),

--- a/lib/integration-tests/tests/integration_tests.rs
+++ b/lib/integration-tests/tests/integration_tests.rs
@@ -519,7 +519,7 @@ async fn test_browser_lifecycle() {
     }
 
     browser
-        .apply(BrowserAction::Reload, Duration::from_millis(500))
+        .apply(BrowserAction::Reload)
         .unwrap();
 
     match browser.next_event().await.unwrap() {


### PR DESCRIPTION
Instead of fixed timeouts per action type, we now get a dynamic system that tracks activity on the page and detects when things are quiescent, i.e. when it's time to capture state. If there's continuous network activity or new rendered frames, there's a max timeout that fires.