### PR TITLE
try hybrid nix caching approach

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,30 @@
+name: Setup Nix
+description: >
+  Install Nix with the Determinate installer, restore /nix/store from the
+  GitHub Actions cache, and configure cachix as a secondary substituter.
+
+inputs:
+  cachix-auth-token:
+    description: Cachix auth token (optional; cachix still works as a substituter without it)
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: DeterminateSystems/nix-installer-action@main
+
+    - uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/flake.lock', '**/Cargo.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-
+        gc-max-store-size-linux: 5G
+        gc-max-store-size-macos: 5G
+        purge: true
+        purge-prefixes: nix-${{ runner.os }}-${{ runner.arch }}-
+        purge-created: 0
+        purge-primary-key: never
+
+    - uses: cachix/cachix-action@v15
+      with:
+        name: bombadil
+        authToken: ${{ inputs.cachix-auth-token }}

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,7 +1,7 @@
 name: Setup Nix
 description: >
-  Install Nix with the Determinate installer, restore /nix/store from the
-  GitHub Actions cache, and configure cachix as a secondary substituter.
+  Install Nix via nix-quick-install, restore /nix/store from the GitHub
+  Actions cache, and (on main only) configure cachix for pushing.
 
 inputs:
   scope:
@@ -11,13 +11,20 @@ inputs:
       "npm-package", "manual").
     required: true
   cachix-auth-token:
-    description: Cachix auth token (optional; cachix still works as a substituter without it)
+    description: >
+      Cachix auth token, only used on main pushes to enable cache writes.
+      PRs read cachix as a substituter via flake.nix's nixConfig and don't
+      need a token.
     required: false
 
 runs:
   using: composite
   steps:
-    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: nixbuild/nix-quick-install-action@v34
+      with:
+        nix_conf: |
+          experimental-features = nix-command flakes
+          accept-flake-config = true
 
     - uses: nix-community/cache-nix-action@v6
       with:
@@ -30,7 +37,8 @@ runs:
         purge-created: 0
         purge-primary-key: never
 
-    - uses: cachix/cachix-action@v15
+    - if: github.ref == 'refs/heads/main'
+      uses: cachix/cachix-action@v15
       with:
         name: bombadil
         authToken: ${{ inputs.cachix-auth-token }}

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -4,6 +4,12 @@ description: >
   GitHub Actions cache, and configure cachix as a secondary substituter.
 
 inputs:
+  scope:
+    description: >
+      Cache scope. Use a distinct value per job/closure so parallel jobs
+      don't overwrite or purge each other's caches (e.g. "build-x86_64-linux",
+      "npm-package", "manual").
+    required: true
   cachix-auth-token:
     description: Cachix auth token (optional; cachix still works as a substituter without it)
     required: false
@@ -15,12 +21,12 @@ runs:
 
     - uses: nix-community/cache-nix-action@v6
       with:
-        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/flake.lock', '**/Cargo.lock') }}
-        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ inputs.scope }}-${{ hashFiles('**/flake.lock', '**/Cargo.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-${{ inputs.scope }}-
         gc-max-store-size-linux: 5G
         gc-max-store-size-macos: 5G
         purge: true
-        purge-prefixes: nix-${{ runner.os }}-${{ runner.arch }}-
+        purge-prefixes: nix-${{ runner.os }}-${{ runner.arch }}-${{ inputs.scope }}-
         purge-created: 0
         purge-primary-key: never
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: nixbuild/nix-quick-install-action@v34
-      - uses: cachix/cachix-action@v15
+      - uses: ./.github/actions/setup-nix
         with:
-          name: bombadil
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: nix flake check .
       - name: Build package
         run: nix build .#${{ matrix.package || 'default' }}
@@ -80,11 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: nixbuild/nix-quick-install-action@v34
-      - uses: cachix/cachix-action@v15
+      - uses: ./.github/actions/setup-nix
         with:
-          name: bombadil
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build npm package
         run: nix build .#npm-package
       - name: Copy package
@@ -103,11 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: nixbuild/nix-quick-install-action@v34
-      - uses: cachix/cachix-action@v15
+      - uses: ./.github/actions/setup-nix
         with:
-          name: bombadil
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build manual
         run: nix build .#manual
       - name: Create manual archive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-nix
         with:
+          scope: build-${{ matrix.target }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: nix flake check .
       - name: Build package
@@ -80,6 +81,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-nix
         with:
+          scope: npm-package
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build npm package
         run: nix build .#npm-package
@@ -101,6 +103,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-nix
         with:
+          scope: manual
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build manual
         run: nix build .#manual


### PR DESCRIPTION
Cuts down CI time from ~18 min to ~3 min. Using the quick nix installer and GitHub's caching for the nix store, in addition to Cachix. The Cachix action only runs on `main` though, to keep the public cache fresh (for dev nix shells, mainly.)