### PR TITLE
chore(deps): update libghostty-vt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,7 +2153,7 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 [[package]]
 name = "libghostty-vt"
 version = "0.1.1"
-source = "git+https://github.com/Uzaaft/libghostty-rs?rev=269c5459c1cb0e1fa30a31d77e27b0bb74b0f0aa#269c5459c1cb0e1fa30a31d77e27b0bb74b0f0aa"
+source = "git+https://github.com/Uzaaft/libghostty-rs?rev=455c34200da92e4ef9d56650ab5d716ae639f54d#455c34200da92e4ef9d56650ab5d716ae639f54d"
 dependencies = [
  "bitflags 2.11.1",
  "int-enum",
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "libghostty-vt-sys"
 version = "0.1.1"
-source = "git+https://github.com/Uzaaft/libghostty-rs?rev=269c5459c1cb0e1fa30a31d77e27b0bb74b0f0aa#269c5459c1cb0e1fa30a31d77e27b0bb74b0f0aa"
+source = "git+https://github.com/Uzaaft/libghostty-rs?rev=455c34200da92e4ef9d56650ab5d716ae639f54d#455c34200da92e4ef9d56650ab5d716ae639f54d"
 
 [[package]]
 name = "libm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ include_dir = "0.7.4"
 indoc = "2.0.7"
 insta = "1.43.1"
 js-sys = "0.3"
-libghostty-vt = { git = "https://github.com/Uzaaft/libghostty-rs", rev = "269c5459c1cb0e1fa30a31d77e27b0bb74b0f0aa" }
+libghostty-vt = { git = "https://github.com/Uzaaft/libghostty-rs", rev = "455c34200da92e4ef9d56650ab5d716ae639f54d" }
 log = "0.4.29"
 markup5ever_rcdom = "0.36.0"
 mime_guess = "2.0"

--- a/flake.nix
+++ b/flake.nix
@@ -61,8 +61,8 @@
         ghosttySrc = pkgs.fetchFromGitHub {
           owner = "ghostty-org";
           repo = "ghostty";
-          rev = "6590196661f769dd8f2b3e85d6c98262c4ec5b3b";
-          sha256 = "0bxq9pv568zr6ns5szmhg18id7f68mbkhqaygm641c3cw1df0w8w";
+          rev = "b869a6e5ab0a50ce01e8eb5aa408a02b3cbe4f3a";
+          sha256 = "0zi9p816616w711zkwbqycg0c042jdbcnyg9gqxcf2h3q669xbp8";
         };
         bombadil = pkgs.callPackage ./lib/nix/default.nix {
           inherit craneLib craneLibStatic ghosttySrc;

--- a/lib/bombadil-terminal/Cargo.toml
+++ b/lib/bombadil-terminal/Cargo.toml
@@ -8,7 +8,7 @@ anyhow.workspace = true
 boa_engine.workspace = true
 bombadil = { path = "../bombadil" }
 bombadil-schema = { path = "../bombadil-schema" }
-libghostty-vt = { workspace = true, features = ["link-static"] }
+libghostty-vt.workspace = true
 log.workspace = true
 portable-pty.workspace = true
 rand.workspace = true


### PR DESCRIPTION
static linking is default. :) I was hoping for gridref to be useful to bombadil but after skimming bombadil it doesnt seem so