### PR TITLE
Release/0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # The Bombadil Changelog
 
+## 0.5.1
+
+* added MouseDrag & SetViewPort
+* Log chosen action, not last action (#186)
+* Add missing terminal CLI args (#185)
+* chore(deps): update libghostty-vt (#184)
+* Decouple browser and make terminal driver first-class (#183)
+* try hybrid nix caching approach (#182)
+
 ## 0.5.0
 
 Major updates:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "bombadil"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "boa_engine",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "bombadil-browser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -456,11 +456,11 @@ dependencies = [
 
 [[package]]
 name = "bombadil-browser-keys"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "bombadil-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "bombadil-ltl"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "proptest",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "bombadil-schema"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "insta",
  "serde",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "bombadil-terminal"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "boa_engine",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 
 [workspace.dependencies]

--- a/lib/bombadil-browser/src/browser/actions.rs
+++ b/lib/bombadil-browser/src/browser/actions.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use anyhow::{Result, anyhow, bail};
 use bombadil::driver::FromGeneratedAction;
 use chromiumoxide::Page;
-use chromiumoxide::cdp::browser_protocol::{dom, input, page};
+use chromiumoxide::cdp::browser_protocol::{dom, emulation, input, page};
 use serde::{Deserialize, Serialize};
 use serde_json as json;
 use tokio::time::sleep;
@@ -47,6 +47,16 @@ pub enum BrowserAction {
     SetFileInputFiles {
         selector: String,
         files: Vec<String>,
+    },
+    MouseDrag {
+        from: Point,
+        to: Point,
+        steps: u32,
+        delay_millis: u64,
+    },
+    SetViewport {
+        width: u32,
+        height: u32,
     },
 }
 
@@ -186,6 +196,74 @@ impl BrowserAction {
                     dom::SetFileInputFilesParams::builder()
                         .files(files.clone())
                         .node_id(node.node_id)
+                        .build()
+                        .map_err(|err| anyhow!(err))?,
+                )
+                .await?;
+            }
+            BrowserAction::MouseDrag {
+                from,
+                to,
+                steps,
+                delay_millis,
+            } => {
+                // `buttons: 1` (left held) must be set on every event during
+                // the drag so JS sees the held button on mousemove. Chrome
+                // doesn't track button state across CDP events.
+                let dispatch = |event_type, point: Point, buttons: i64| {
+                    input::DispatchMouseEventParams::builder()
+                        .r#type(event_type)
+                        .x(point.x)
+                        .y(point.y)
+                        .button(input::MouseButton::Left)
+                        .buttons(buttons)
+                        .click_count(1)
+                        .build()
+                        .map_err(|err| anyhow!(err))
+                };
+                page.execute(dispatch(
+                    input::DispatchMouseEventType::MousePressed,
+                    *from,
+                    1,
+                )?)
+                .await?;
+                let delay = Duration::from_millis(*delay_millis);
+                let steps = (*steps).max(1);
+                for step in 1..=steps {
+                    let t = step as f64 / steps as f64;
+                    let point = Point {
+                        x: from.x + (to.x - from.x) * t,
+                        y: from.y + (to.y - from.y) * t,
+                    };
+                    if !delay.is_zero() {
+                        sleep(delay).await;
+                    }
+                    page.execute(dispatch(
+                        input::DispatchMouseEventType::MouseMoved,
+                        point,
+                        1,
+                    )?)
+                    .await?;
+                }
+                page.execute(dispatch(
+                    input::DispatchMouseEventType::MouseReleased,
+                    *to,
+                    0,
+                )?)
+                .await?;
+            }
+            BrowserAction::SetViewport { width, height } => {
+                // device_scale_factor is hardcoded to 1.0 here: the launch-time
+                // value isn't reachable from apply()'s &Page-only signature,
+                // and spec authors fuzzing viewports rarely also want to vary
+                // DPR. Add a separate action if that need arises.
+                page.execute(
+                    emulation::SetDeviceMetricsOverrideParams::builder()
+                        .width(*width)
+                        .height(*height)
+                        .device_scale_factor(1.0)
+                        .mobile(false)
+                        .scale(1)
                         .build()
                         .map_err(|err| anyhow!(err))?,
                 )

--- a/lib/bombadil-browser/src/convert.rs
+++ b/lib/bombadil-browser/src/convert.rs
@@ -86,6 +86,23 @@ impl ToSchema<bombadil_schema::BrowserAction> for BrowserAction {
                     files: files.clone(),
                 }
             }
+            BrowserAction::MouseDrag {
+                from,
+                to,
+                steps,
+                delay_millis,
+            } => bombadil_schema::BrowserAction::MouseDrag {
+                from: from.to_schema(),
+                to: to.to_schema(),
+                steps: *steps,
+                delay_millis: *delay_millis,
+            },
+            BrowserAction::SetViewport { width, height } => {
+                bombadil_schema::BrowserAction::SetViewport {
+                    width: *width,
+                    height: *height,
+                }
+            }
         }
     }
 }
@@ -145,6 +162,23 @@ impl ToInternal<BrowserAction> for bombadil_schema::BrowserAction {
                 selector: selector.clone(),
                 files: files.clone(),
             },
+            bombadil_schema::BrowserAction::MouseDrag {
+                from,
+                to,
+                steps,
+                delay_millis,
+            } => BrowserAction::MouseDrag {
+                from: from.to_internal(),
+                to: to.to_internal(),
+                steps: *steps,
+                delay_millis: *delay_millis,
+            },
+            bombadil_schema::BrowserAction::SetViewport { width, height } => {
+                BrowserAction::SetViewport {
+                    width: *width,
+                    height: *height,
+                }
+            }
         }
     }
 }

--- a/lib/bombadil-browser/src/js_action.rs
+++ b/lib/bombadil-browser/src/js_action.rs
@@ -48,6 +48,18 @@ pub enum JsAction {
         selector: String,
         files: Vec<String>,
     },
+    #[serde(rename_all = "camelCase")]
+    MouseDrag {
+        from: Point,
+        to: Point,
+        steps: f64,
+        delay_millis: f64,
+    },
+    #[serde(rename_all = "camelCase")]
+    SetViewport {
+        width: f64,
+        height: f64,
+    },
 }
 
 impl JsAction {
@@ -125,6 +137,58 @@ impl JsAction {
             JsAction::Wait => BrowserAction::Wait,
             JsAction::SetFileInputFiles { selector, files } => {
                 BrowserAction::SetFileInputFiles { selector, files }
+            }
+            JsAction::MouseDrag {
+                from,
+                to,
+                steps,
+                delay_millis,
+            } => {
+                if !steps.is_finite()
+                    || !(1.0..=10_000.0).contains(&steps)
+                    || steps.fract() != 0.0
+                {
+                    bail!(
+                        "steps must be an integer between 1 and 10000, got {}",
+                        steps
+                    );
+                }
+                if !delay_millis.is_finite() || delay_millis < 0.0 {
+                    bail!(
+                        "delayMillis must be a non-negative finite number, got {}",
+                        delay_millis
+                    );
+                }
+                if delay_millis > 1000.0 {
+                    bail!(
+                        "delayMillis must be at most 1000, got {}",
+                        delay_millis
+                    );
+                }
+                BrowserAction::MouseDrag {
+                    from,
+                    to,
+                    steps: steps as u32,
+                    delay_millis: delay_millis as u64,
+                }
+            }
+            JsAction::SetViewport { width, height } => {
+                for (name, value) in [("width", width), ("height", height)] {
+                    if !value.is_finite()
+                        || !(1.0..=10_000.0).contains(&value)
+                        || value.fract() != 0.0
+                    {
+                        bail!(
+                            "{} must be an integer between 1 and 10000, got {}",
+                            name,
+                            value
+                        );
+                    }
+                }
+                BrowserAction::SetViewport {
+                    width: width as u32,
+                    height: height as u32,
+                }
             }
         })
     }
@@ -205,5 +269,68 @@ mod tests {
         let result = js_action.into_browser_action();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("finite"));
+    }
+
+    #[test]
+    fn test_mouse_drag_round_trip() {
+        let json = r#"{"MouseDrag": {"from": {"x": 1.0, "y": 2.0}, "to": {"x": 100.0, "y": 200.0}, "steps": 10.0, "delayMillis": 5.0}}"#;
+        let action: JsAction = serde_json::from_str(json).unwrap();
+        let browser_action = action.into_browser_action().unwrap();
+        match browser_action {
+            BrowserAction::MouseDrag {
+                from,
+                to,
+                steps,
+                delay_millis,
+            } => {
+                assert_eq!((from.x, from.y), (1.0, 2.0));
+                assert_eq!((to.x, to.y), (100.0, 200.0));
+                assert_eq!(steps, 10);
+                assert_eq!(delay_millis, 5);
+            }
+            _ => panic!("expected MouseDrag"),
+        }
+    }
+
+    #[test]
+    fn test_mouse_drag_validates_steps() {
+        let make = |steps: f64| JsAction::MouseDrag {
+            from: Point { x: 0.0, y: 0.0 },
+            to: Point { x: 1.0, y: 1.0 },
+            steps,
+            delay_millis: 0.0,
+        };
+
+        assert!(make(0.0).into_browser_action().is_err());
+        assert!(make(10_001.0).into_browser_action().is_err());
+        assert!(make(1.5).into_browser_action().is_err());
+        assert!(make(f64::NAN).into_browser_action().is_err());
+    }
+
+    #[test]
+    fn test_set_viewport_round_trip() {
+        let json = r#"{"SetViewport": {"width": 1024.0, "height": 768.0}}"#;
+        let action: JsAction = serde_json::from_str(json).unwrap();
+        let browser_action = action.into_browser_action().unwrap();
+        match browser_action {
+            BrowserAction::SetViewport { width, height } => {
+                assert_eq!(width, 1024);
+                assert_eq!(height, 768);
+            }
+            _ => panic!("expected SetViewport"),
+        }
+    }
+
+    #[test]
+    fn test_set_viewport_validates_dimensions() {
+        let make =
+            |width: f64, height: f64| JsAction::SetViewport { width, height };
+
+        assert!(make(0.0, 600.0).into_browser_action().is_err());
+        assert!(make(800.0, 0.0).into_browser_action().is_err());
+        assert!(make(-1.0, 600.0).into_browser_action().is_err());
+        assert!(make(10_001.0, 600.0).into_browser_action().is_err());
+        assert!(make(800.5, 600.0).into_browser_action().is_err());
+        assert!(make(f64::NAN, 600.0).into_browser_action().is_err());
     }
 }

--- a/lib/bombadil-browser/src/render.rs
+++ b/lib/bombadil-browser/src/render.rs
@@ -102,5 +102,30 @@ pub fn format_action(action: &BrowserAction) -> String {
                 styled::maybe_blue(format!("{}", files.len()))
             )
         }
+        BrowserAction::MouseDrag {
+            from,
+            to,
+            steps,
+            delay_millis,
+        } => {
+            format!(
+                "{} from (x: {}, y: {}) to (x: {}, y: {}) ({} steps, delay: {})",
+                styled::maybe_bold("Dragging".to_string()),
+                styled::maybe_blue(format!("{:.1}", from.x)),
+                styled::maybe_blue(format!("{:.1}", from.y)),
+                styled::maybe_blue(format!("{:.1}", to.x)),
+                styled::maybe_blue(format!("{:.1}", to.y)),
+                styled::maybe_blue(format!("{steps}")),
+                styled::maybe_blue(format!("{delay_millis}ms"))
+            )
+        }
+        BrowserAction::SetViewport { width, height } => {
+            format!(
+                "{} to {}x{}",
+                styled::maybe_bold("Setting viewport".to_string()),
+                styled::maybe_blue(format!("{width}")),
+                styled::maybe_blue(format!("{height}"))
+            )
+        }
     }
 }

--- a/lib/bombadil-inspect/src/actions.rs
+++ b/lib/bombadil-inspect/src/actions.rs
@@ -172,6 +172,27 @@ fn ActionEntry(props: &HistoryEntryProps) -> Html {
                         ("Files", format!("{} file(s)", files.len())),
                     ]),
                 ),
+                bombadil_schema::BrowserAction::MouseDrag {
+                    from,
+                    to,
+                    steps,
+                    delay_millis,
+                } => (
+                    html!(<span class="action-name">{"Mouse drag"}</span>),
+                    Some(vec![
+                        ("From", format_point(from)),
+                        ("To", format_point(to)),
+                        ("Steps", steps.to_string()),
+                        ("Delay", format!("{}ms", delay_millis)),
+                    ]),
+                ),
+                bombadil_schema::BrowserAction::SetViewport {
+                    width,
+                    height,
+                } => (
+                    html!(<span class="action-name">{"Set viewport"}</span>),
+                    Some(vec![("Size", format!("{width}x{height}"))]),
+                ),
             },
             None => return html! {},
         };

--- a/lib/bombadil-schema/src/schema.rs
+++ b/lib/bombadil-schema/src/schema.rs
@@ -136,6 +136,16 @@ pub enum BrowserAction {
         selector: String,
         files: Vec<String>,
     },
+    MouseDrag {
+        from: Point,
+        to: Point,
+        steps: u32,
+        delay_millis: u64,
+    },
+    SetViewport {
+        width: u32,
+        height: u32,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/lib/bombadil/src/specification/browser/index.ts
+++ b/lib/bombadil/src/specification/browser/index.ts
@@ -29,7 +29,16 @@ export type Action =
   | { PressKey: { code: number } }
   | { ScrollUp: { origin: Point; distance: number } }
   | { ScrollDown: { origin: Point; distance: number } }
-  | { SetFileInputFiles: { selector: string; files: string[] } };
+  | { SetFileInputFiles: { selector: string; files: string[] } }
+  | {
+    MouseDrag: {
+      from: Point;
+      to: Point;
+      steps: number;
+      delayMillis: number;
+    };
+  }
+  | { SetViewport: { width: number; height: number } };
 
 export interface State {
   document: HTMLDocument;

--- a/lib/integration-tests/tests/integration_tests.rs
+++ b/lib/integration-tests/tests/integration_tests.rs
@@ -938,3 +938,60 @@ export const keepRunning = always(() => true);
         .run()
         .await;
 }
+
+#[tokio::test]
+async fn test_mouse_drag() {
+    BrowserIntegrationTest::new("mouse-drag")
+        .time_limit(Duration::from_secs(5))
+        .specification(
+            r##"
+import { eventually } from "@antithesishq/bombadil";
+import { actions, extract } from "@antithesishq/bombadil/browser";
+
+const status = extract((state) => {
+  const element = state.document.body.querySelector("#status");
+  return element?.textContent ?? "";
+});
+
+export const drag = actions(() => [
+  {
+    MouseDrag: {
+      from: { x: 100, y: 200 },
+      to: { x: 400, y: 200 },
+      steps: 5,
+      delayMillis: 10,
+    },
+  },
+]);
+
+export const wasDragged = eventually(() => status.current === "dragged");
+"##,
+        )
+        .run()
+        .await;
+}
+
+#[tokio::test]
+async fn test_set_viewport() {
+    BrowserIntegrationTest::new("set-viewport")
+        .time_limit(Duration::from_secs(5))
+        .specification(
+            r##"
+import { eventually } from "@antithesishq/bombadil";
+import { actions, extract } from "@antithesishq/bombadil/browser";
+
+const size = extract((state) => {
+  const element = state.document.body.querySelector("#size");
+  return element?.textContent ?? "";
+});
+
+export const resize = actions(() => [
+  { SetViewport: { width: 1024, height: 768 } },
+]);
+
+export const viewportApplied = eventually(() => size.current === "1024x768");
+"##,
+        )
+        .run()
+        .await;
+}

--- a/lib/integration-tests/tests/mouse-drag/index.html
+++ b/lib/integration-tests/tests/mouse-drag/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mouse Drag Test</title>
+</head>
+<body>
+    <h1>Mouse Drag Test</h1>
+    <div id="status">pending</div>
+    <div id="surface" style="width:600px;height:400px;background:#eef;position:relative;"></div>
+    <script>
+        const surface = document.getElementById('surface');
+        const status = document.getElementById('status');
+        let down = false;
+        let moves = 0;
+
+        surface.addEventListener('mousedown', () => {
+            down = true;
+            moves = 0;
+        });
+        surface.addEventListener('mousemove', (event) => {
+            if (down && event.buttons & 1) {
+                moves++;
+            }
+        });
+        surface.addEventListener('mouseup', () => {
+            if (down && moves > 0) {
+                status.textContent = 'dragged';
+            }
+            down = false;
+        });
+    </script>
+</body>
+</html>

--- a/lib/integration-tests/tests/set-viewport/index.html
+++ b/lib/integration-tests/tests/set-viewport/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Set Viewport Test</title>
+</head>
+<body>
+    <h1>Set Viewport Test</h1>
+    <div id="size">0x0</div>
+    <script>
+        const sizeElement = document.getElementById('size');
+        function update() {
+            sizeElement.textContent = `${window.innerWidth}x${window.innerHeight}`;
+        }
+        update();
+        window.addEventListener('resize', update);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Adds two new native `BrowserAction` variants:

  - **`MouseDrag { from, to, steps, delayMillis }`** - left-button drag
  via `Input.dispatchMouseEvent` (Pressed -> N x Moved -> Released),
  interpolated along the line.
  
  - **`SetViewport { width, height }`** - runtime viewport change via
  `Emulation.setDeviceMetricsOverride`.



  Wired through the existing pipeline: `BrowserAction` -> `JsAction` (with
   bounds validation) -> CDP dispatch -> trace schema -> TS `Action` union ->
   CLI/Inspect renderers.