### PR TITLE
Added MouseDrag & SetViewPort

### DIFF
--- a/lib/bombadil-browser/src/browser.rs
+++ b/lib/bombadil-browser/src/browser.rs
@@ -27,7 +27,7 @@ use tokio::{select, spawn};
 use tokio_stream::wrappers::BroadcastStream;
 use url::Url;
 
-use crate::browser::actions::BrowserAction;
+use crate::browser::actions::{ActionOptions, BrowserAction};
 use crate::browser::state::{
     BrowserState, CallFrame, ConsoleEntry, Exception, Screenshot,
     ScreenshotFormat,
@@ -160,6 +160,7 @@ struct BrowserContext {
     latest_frame: Arc<Mutex<Option<Arc<[u8]>>>>,
     #[allow(unused, reason = "this is going into the scripts soon")]
     origin: Url,
+    browser_options: BrowserOptions,
 }
 
 #[derive(Clone)]
@@ -383,6 +384,7 @@ impl Browser {
             screencast_activity,
             latest_frame,
             origin: origin.clone(),
+            browser_options: browser_options.clone(),
         };
 
         instrumentation::instrument_js_coverage(
@@ -964,6 +966,12 @@ async fn process_event(
         ) => {
             let page = context.page.clone();
             let sender = context.inner_events_sender.clone();
+            let action_options = ActionOptions {
+                device_scale_factor: context
+                    .browser_options
+                    .emulation
+                    .device_scale_factor,
+            };
             // We can't block on running the action, in case it
             // synchronously throws an uncaught exception blocking the
             // evaluation indefinitely. This gives us a chance to
@@ -971,7 +979,7 @@ async fn process_event(
             // (extracting the uncaught exception information).
             spawn(async move {
                 log::debug!("applying: {:?}", browser_action);
-                match browser_action.apply(&page).await {
+                match browser_action.apply(&page, action_options).await {
                     Ok(_) => {
                         log::debug!("applied: {:?}", browser_action);
                     }

--- a/lib/bombadil-browser/src/browser/actions.rs
+++ b/lib/bombadil-browser/src/browser/actions.rs
@@ -12,6 +12,11 @@ use crate::geometry::Point;
 use crate::js_action::JsAction;
 use bombadil_browser_keys::key_name;
 
+#[derive(Clone, Copy, Debug)]
+pub struct ActionOptions {
+    pub device_scale_factor: f64,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum BrowserAction {
     Back,
@@ -68,7 +73,11 @@ impl FromGeneratedAction for BrowserAction {
 }
 
 impl BrowserAction {
-    pub async fn apply(&self, page: &Page) -> Result<()> {
+    pub async fn apply(
+        &self,
+        page: &Page,
+        options: ActionOptions,
+    ) -> Result<()> {
         match self {
             BrowserAction::Back => {
                 let history =
@@ -253,15 +262,11 @@ impl BrowserAction {
                 .await?;
             }
             BrowserAction::SetViewport { width, height } => {
-                // device_scale_factor is hardcoded to 1.0 here: the launch-time
-                // value isn't reachable from apply()'s &Page-only signature,
-                // and spec authors fuzzing viewports rarely also want to vary
-                // DPR. Add a separate action if that need arises.
                 page.execute(
                     emulation::SetDeviceMetricsOverrideParams::builder()
                         .width(u32::from(*width))
                         .height(u32::from(*height))
-                        .device_scale_factor(1.0)
+                        .device_scale_factor(options.device_scale_factor)
                         .mobile(false)
                         .scale(1)
                         .build()

--- a/lib/bombadil-browser/src/browser/actions.rs
+++ b/lib/bombadil-browser/src/browser/actions.rs
@@ -51,7 +51,7 @@ pub enum BrowserAction {
     MouseDrag {
         from: Point,
         to: Point,
-        steps: u32,
+        steps: u8,
         delay_millis: u64,
     },
     SetViewport {
@@ -230,10 +230,10 @@ impl BrowserAction {
                 let delay = Duration::from_millis(*delay_millis);
                 let steps = (*steps).max(1);
                 for step in 1..=steps {
-                    let t = step as f64 / steps as f64;
+                    let progress = step as f64 / steps as f64;
                     let point = Point {
-                        x: from.x + (to.x - from.x) * t,
-                        y: from.y + (to.y - from.y) * t,
+                        x: from.x + (to.x - from.x) * progress,
+                        y: from.y + (to.y - from.y) * progress,
                     };
                     if !delay.is_zero() {
                         sleep(delay).await;

--- a/lib/bombadil-browser/src/browser/actions.rs
+++ b/lib/bombadil-browser/src/browser/actions.rs
@@ -55,8 +55,8 @@ pub enum BrowserAction {
         delay_millis: u64,
     },
     SetViewport {
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
     },
 }
 
@@ -259,8 +259,8 @@ impl BrowserAction {
                 // DPR. Add a separate action if that need arises.
                 page.execute(
                     emulation::SetDeviceMetricsOverrideParams::builder()
-                        .width(*width)
-                        .height(*height)
+                        .width(u32::from(*width))
+                        .height(u32::from(*height))
                         .device_scale_factor(1.0)
                         .mobile(false)
                         .scale(1)

--- a/lib/bombadil-browser/src/browser/actions.rs
+++ b/lib/bombadil-browser/src/browser/actions.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use anyhow::{Result, anyhow, bail};
 use bombadil::driver::FromGeneratedAction;
 use chromiumoxide::Page;
-use chromiumoxide::cdp::browser_protocol::{dom, input, page};
+use chromiumoxide::cdp::browser_protocol::{dom, emulation, input, page};
 use serde::{Deserialize, Serialize};
 use serde_json as json;
 use tokio::time::sleep;
@@ -47,6 +47,16 @@ pub enum BrowserAction {
     SetFileInputFiles {
         selector: String,
         files: Vec<String>,
+    },
+    MouseDrag {
+        from: Point,
+        to: Point,
+        steps: u32,
+        delay_millis: u64,
+    },
+    SetViewport {
+        width: u32,
+        height: u32,
     },
 }
 
@@ -186,6 +196,74 @@ impl BrowserAction {
                     dom::SetFileInputFilesParams::builder()
                         .files(files.clone())
                         .node_id(node.node_id)
+                        .build()
+                        .map_err(|err| anyhow!(err))?,
+                )
+                .await?;
+            }
+            BrowserAction::MouseDrag {
+                from,
+                to,
+                steps,
+                delay_millis,
+            } => {
+                // `buttons: 1` (left held) must be set on every event during
+                // the drag so JS sees the held button on mousemove. Chrome
+                // doesn't track button state across CDP events.
+                let dispatch = |event_type, point: Point, buttons: i64| {
+                    input::DispatchMouseEventParams::builder()
+                        .r#type(event_type)
+                        .x(point.x)
+                        .y(point.y)
+                        .button(input::MouseButton::Left)
+                        .buttons(buttons)
+                        .click_count(1)
+                        .build()
+                        .map_err(|err| anyhow!(err))
+                };
+                page.execute(dispatch(
+                    input::DispatchMouseEventType::MousePressed,
+                    *from,
+                    1,
+                )?)
+                .await?;
+                let delay = Duration::from_millis(*delay_millis);
+                let steps = (*steps).max(1);
+                for step in 1..=steps {
+                    let t = step as f64 / steps as f64;
+                    let point = Point {
+                        x: from.x + (to.x - from.x) * t,
+                        y: from.y + (to.y - from.y) * t,
+                    };
+                    if !delay.is_zero() {
+                        sleep(delay).await;
+                    }
+                    page.execute(dispatch(
+                        input::DispatchMouseEventType::MouseMoved,
+                        point,
+                        1,
+                    )?)
+                    .await?;
+                }
+                page.execute(dispatch(
+                    input::DispatchMouseEventType::MouseReleased,
+                    *to,
+                    0,
+                )?)
+                .await?;
+            }
+            BrowserAction::SetViewport { width, height } => {
+                // device_scale_factor is hardcoded to 1.0 here: the launch-time
+                // value isn't reachable from apply()'s &Page-only signature,
+                // and spec authors fuzzing viewports rarely also want to vary
+                // DPR. Add a separate action if that need arises.
+                page.execute(
+                    emulation::SetDeviceMetricsOverrideParams::builder()
+                        .width(*width)
+                        .height(*height)
+                        .device_scale_factor(1.0)
+                        .mobile(false)
+                        .scale(1)
                         .build()
                         .map_err(|err| anyhow!(err))?,
                 )

--- a/lib/bombadil-browser/src/convert.rs
+++ b/lib/bombadil-browser/src/convert.rs
@@ -86,6 +86,23 @@ impl ToSchema<bombadil_schema::BrowserAction> for BrowserAction {
                     files: files.clone(),
                 }
             }
+            BrowserAction::MouseDrag {
+                from,
+                to,
+                steps,
+                delay_millis,
+            } => bombadil_schema::BrowserAction::MouseDrag {
+                from: from.to_schema(),
+                to: to.to_schema(),
+                steps: *steps,
+                delay_millis: *delay_millis,
+            },
+            BrowserAction::SetViewport { width, height } => {
+                bombadil_schema::BrowserAction::SetViewport {
+                    width: *width,
+                    height: *height,
+                }
+            }
         }
     }
 }
@@ -145,6 +162,23 @@ impl ToInternal<BrowserAction> for bombadil_schema::BrowserAction {
                 selector: selector.clone(),
                 files: files.clone(),
             },
+            bombadil_schema::BrowserAction::MouseDrag {
+                from,
+                to,
+                steps,
+                delay_millis,
+            } => BrowserAction::MouseDrag {
+                from: from.to_internal(),
+                to: to.to_internal(),
+                steps: *steps,
+                delay_millis: *delay_millis,
+            },
+            bombadil_schema::BrowserAction::SetViewport { width, height } => {
+                BrowserAction::SetViewport {
+                    width: *width,
+                    height: *height,
+                }
+            }
         }
     }
 }

--- a/lib/bombadil-browser/src/js_action.rs
+++ b/lib/bombadil-browser/src/js_action.rs
@@ -145,11 +145,11 @@ impl JsAction {
                 delay_millis,
             } => {
                 if !steps.is_finite()
-                    || !(1.0..=10_000.0).contains(&steps)
+                    || !(1.0..=255.0).contains(&steps)
                     || steps.fract() != 0.0
                 {
                     bail!(
-                        "steps must be an integer between 1 and 10000, got {}",
+                        "steps must be an integer between 1 and 255, got {}",
                         steps
                     );
                 }
@@ -168,7 +168,7 @@ impl JsAction {
                 BrowserAction::MouseDrag {
                     from,
                     to,
-                    steps: steps as u32,
+                    steps: steps as u8,
                     delay_millis: delay_millis as u64,
                 }
             }
@@ -302,7 +302,7 @@ mod tests {
         };
 
         assert!(make(0.0).into_browser_action().is_err());
-        assert!(make(10_001.0).into_browser_action().is_err());
+        assert!(make(256.0).into_browser_action().is_err());
         assert!(make(1.5).into_browser_action().is_err());
         assert!(make(f64::NAN).into_browser_action().is_err());
     }

--- a/lib/bombadil-browser/src/js_action.rs
+++ b/lib/bombadil-browser/src/js_action.rs
@@ -186,8 +186,8 @@ impl JsAction {
                     }
                 }
                 BrowserAction::SetViewport {
-                    width: width as u32,
-                    height: height as u32,
+                    width: width as u16,
+                    height: height as u16,
                 }
             }
         })

--- a/lib/bombadil-browser/src/js_action.rs
+++ b/lib/bombadil-browser/src/js_action.rs
@@ -48,6 +48,18 @@ pub enum JsAction {
         selector: String,
         files: Vec<String>,
     },
+    #[serde(rename_all = "camelCase")]
+    MouseDrag {
+        from: Point,
+        to: Point,
+        steps: f64,
+        delay_millis: f64,
+    },
+    #[serde(rename_all = "camelCase")]
+    SetViewport {
+        width: f64,
+        height: f64,
+    },
 }
 
 impl JsAction {
@@ -125,6 +137,58 @@ impl JsAction {
             JsAction::Wait => BrowserAction::Wait,
             JsAction::SetFileInputFiles { selector, files } => {
                 BrowserAction::SetFileInputFiles { selector, files }
+            }
+            JsAction::MouseDrag {
+                from,
+                to,
+                steps,
+                delay_millis,
+            } => {
+                if !steps.is_finite()
+                    || !(1.0..=10_000.0).contains(&steps)
+                    || steps.fract() != 0.0
+                {
+                    bail!(
+                        "steps must be an integer between 1 and 10000, got {}",
+                        steps
+                    );
+                }
+                if !delay_millis.is_finite() || delay_millis < 0.0 {
+                    bail!(
+                        "delayMillis must be a non-negative finite number, got {}",
+                        delay_millis
+                    );
+                }
+                if delay_millis > 1000.0 {
+                    bail!(
+                        "delayMillis must be at most 1000, got {}",
+                        delay_millis
+                    );
+                }
+                BrowserAction::MouseDrag {
+                    from,
+                    to,
+                    steps: steps as u32,
+                    delay_millis: delay_millis as u64,
+                }
+            }
+            JsAction::SetViewport { width, height } => {
+                for (name, value) in [("width", width), ("height", height)] {
+                    if !value.is_finite()
+                        || !(1.0..=10_000.0).contains(&value)
+                        || value.fract() != 0.0
+                    {
+                        bail!(
+                            "{} must be an integer between 1 and 10000, got {}",
+                            name,
+                            value
+                        );
+                    }
+                }
+                BrowserAction::SetViewport {
+                    width: width as u32,
+                    height: height as u32,
+                }
             }
         })
     }
@@ -205,5 +269,68 @@ mod tests {
         let result = js_action.into_browser_action();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("finite"));
+    }
+
+    #[test]
+    fn test_mouse_drag_round_trip() {
+        let json = r#"{"MouseDrag": {"from": {"x": 1.0, "y": 2.0}, "to": {"x": 100.0, "y": 200.0}, "steps": 10.0, "delayMillis": 5.0}}"#;
+        let action: JsAction = serde_json::from_str(json).unwrap();
+        let browser_action = action.into_browser_action().unwrap();
+        match browser_action {
+            BrowserAction::MouseDrag {
+                from,
+                to,
+                steps,
+                delay_millis,
+            } => {
+                assert_eq!((from.x, from.y), (1.0, 2.0));
+                assert_eq!((to.x, to.y), (100.0, 200.0));
+                assert_eq!(steps, 10);
+                assert_eq!(delay_millis, 5);
+            }
+            _ => panic!("expected MouseDrag"),
+        }
+    }
+
+    #[test]
+    fn test_mouse_drag_validates_steps() {
+        let make = |steps: f64| JsAction::MouseDrag {
+            from: Point { x: 0.0, y: 0.0 },
+            to: Point { x: 1.0, y: 1.0 },
+            steps,
+            delay_millis: 0.0,
+        };
+
+        assert!(make(0.0).into_browser_action().is_err());
+        assert!(make(10_001.0).into_browser_action().is_err());
+        assert!(make(1.5).into_browser_action().is_err());
+        assert!(make(f64::NAN).into_browser_action().is_err());
+    }
+
+    #[test]
+    fn test_set_viewport_round_trip() {
+        let json = r#"{"SetViewport": {"width": 1024.0, "height": 768.0}}"#;
+        let action: JsAction = serde_json::from_str(json).unwrap();
+        let browser_action = action.into_browser_action().unwrap();
+        match browser_action {
+            BrowserAction::SetViewport { width, height } => {
+                assert_eq!(width, 1024);
+                assert_eq!(height, 768);
+            }
+            _ => panic!("expected SetViewport"),
+        }
+    }
+
+    #[test]
+    fn test_set_viewport_validates_dimensions() {
+        let make =
+            |width: f64, height: f64| JsAction::SetViewport { width, height };
+
+        assert!(make(0.0, 600.0).into_browser_action().is_err());
+        assert!(make(800.0, 0.0).into_browser_action().is_err());
+        assert!(make(-1.0, 600.0).into_browser_action().is_err());
+        assert!(make(10_001.0, 600.0).into_browser_action().is_err());
+        assert!(make(800.5, 600.0).into_browser_action().is_err());
+        assert!(make(f64::NAN, 600.0).into_browser_action().is_err());
     }
 }

--- a/lib/bombadil-browser/src/render.rs
+++ b/lib/bombadil-browser/src/render.rs
@@ -102,5 +102,30 @@ pub fn format_action(action: &BrowserAction) -> String {
                 styled::maybe_blue(format!("{}", files.len()))
             )
         }
+        BrowserAction::MouseDrag {
+            from,
+            to,
+            steps,
+            delay_millis,
+        } => {
+            format!(
+                "{} from (x: {}, y: {}) to (x: {}, y: {}) ({} steps, delay: {})",
+                styled::maybe_bold("Dragging".to_string()),
+                styled::maybe_blue(format!("{:.1}", from.x)),
+                styled::maybe_blue(format!("{:.1}", from.y)),
+                styled::maybe_blue(format!("{:.1}", to.x)),
+                styled::maybe_blue(format!("{:.1}", to.y)),
+                styled::maybe_blue(format!("{steps}")),
+                styled::maybe_blue(format!("{delay_millis}ms"))
+            )
+        }
+        BrowserAction::SetViewport { width, height } => {
+            format!(
+                "{} to {}x{}",
+                styled::maybe_bold("Setting viewport".to_string()),
+                styled::maybe_blue(format!("{width}")),
+                styled::maybe_blue(format!("{height}"))
+            )
+        }
     }
 }

--- a/lib/bombadil-inspect/src/actions.rs
+++ b/lib/bombadil-inspect/src/actions.rs
@@ -172,6 +172,27 @@ fn ActionEntry(props: &HistoryEntryProps) -> Html {
                         ("Files", format!("{} file(s)", files.len())),
                     ]),
                 ),
+                bombadil_schema::BrowserAction::MouseDrag {
+                    from,
+                    to,
+                    steps,
+                    delay_millis,
+                } => (
+                    html!(<span class="action-name">{"Mouse drag"}</span>),
+                    Some(vec![
+                        ("From", format_point(from)),
+                        ("To", format_point(to)),
+                        ("Steps", steps.to_string()),
+                        ("Delay", format!("{}ms", delay_millis)),
+                    ]),
+                ),
+                bombadil_schema::BrowserAction::SetViewport {
+                    width,
+                    height,
+                } => (
+                    html!(<span class="action-name">{"Set viewport"}</span>),
+                    Some(vec![("Size", format!("{width}x{height}"))]),
+                ),
             },
             None => return html! {},
         };

--- a/lib/bombadil-schema/src/schema.rs
+++ b/lib/bombadil-schema/src/schema.rs
@@ -136,6 +136,16 @@ pub enum BrowserAction {
         selector: String,
         files: Vec<String>,
     },
+    MouseDrag {
+        from: Point,
+        to: Point,
+        steps: u32,
+        delay_millis: u64,
+    },
+    SetViewport {
+        width: u32,
+        height: u32,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/lib/bombadil-schema/src/schema.rs
+++ b/lib/bombadil-schema/src/schema.rs
@@ -139,7 +139,7 @@ pub enum BrowserAction {
     MouseDrag {
         from: Point,
         to: Point,
-        steps: u32,
+        steps: u8,
         delay_millis: u64,
     },
     SetViewport {

--- a/lib/bombadil-schema/src/schema.rs
+++ b/lib/bombadil-schema/src/schema.rs
@@ -143,8 +143,8 @@ pub enum BrowserAction {
         delay_millis: u64,
     },
     SetViewport {
-        width: u32,
-        height: u32,
+        width: u16,
+        height: u16,
     },
 }
 

--- a/lib/bombadil/src/specification/browser/index.ts
+++ b/lib/bombadil/src/specification/browser/index.ts
@@ -29,7 +29,16 @@ export type Action =
   | { PressKey: { code: number } }
   | { ScrollUp: { origin: Point; distance: number } }
   | { ScrollDown: { origin: Point; distance: number } }
-  | { SetFileInputFiles: { selector: string; files: string[] } };
+  | { SetFileInputFiles: { selector: string; files: string[] } }
+  | {
+    MouseDrag: {
+      from: Point;
+      to: Point;
+      steps: number;
+      delayMillis: number;
+    };
+  }
+  | { SetViewport: { width: number; height: number } };
 
 export interface State {
   document: HTMLDocument;

--- a/lib/integration-tests/tests/integration_tests.rs
+++ b/lib/integration-tests/tests/integration_tests.rs
@@ -938,3 +938,60 @@ export const keepRunning = always(() => true);
         .run()
         .await;
 }
+
+#[tokio::test]
+async fn test_mouse_drag() {
+    BrowserIntegrationTest::new("mouse-drag")
+        .time_limit(Duration::from_secs(5))
+        .specification(
+            r##"
+import { eventually } from "@antithesishq/bombadil";
+import { actions, extract } from "@antithesishq/bombadil/browser";
+
+const status = extract((state) => {
+  const element = state.document.body.querySelector("#status");
+  return element?.textContent ?? "";
+});
+
+export const drag = actions(() => [
+  {
+    MouseDrag: {
+      from: { x: 100, y: 200 },
+      to: { x: 400, y: 200 },
+      steps: 5,
+      delayMillis: 10,
+    },
+  },
+]);
+
+export const wasDragged = eventually(() => status.current === "dragged");
+"##,
+        )
+        .run()
+        .await;
+}
+
+#[tokio::test]
+async fn test_set_viewport() {
+    BrowserIntegrationTest::new("set-viewport")
+        .time_limit(Duration::from_secs(5))
+        .specification(
+            r##"
+import { eventually } from "@antithesishq/bombadil";
+import { actions, extract } from "@antithesishq/bombadil/browser";
+
+const size = extract((state) => {
+  const element = state.document.body.querySelector("#size");
+  return element?.textContent ?? "";
+});
+
+export const resize = actions(() => [
+  { SetViewport: { width: 1024, height: 768 } },
+]);
+
+export const viewportApplied = eventually(() => size.current === "1024x768");
+"##,
+        )
+        .run()
+        .await;
+}

--- a/lib/integration-tests/tests/mouse-drag/index.html
+++ b/lib/integration-tests/tests/mouse-drag/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mouse Drag Test</title>
+</head>
+<body>
+    <h1>Mouse Drag Test</h1>
+    <div id="status">pending</div>
+    <div id="surface" style="width:600px;height:400px;background:#eef;position:relative;"></div>
+    <script>
+        const surface = document.getElementById('surface');
+        const status = document.getElementById('status');
+        let down = false;
+        let moves = 0;
+
+        surface.addEventListener('mousedown', () => {
+            down = true;
+            moves = 0;
+        });
+        surface.addEventListener('mousemove', (event) => {
+            if (down && event.buttons & 1) {
+                moves++;
+            }
+        });
+        surface.addEventListener('mouseup', () => {
+            if (down && moves > 0) {
+                status.textContent = 'dragged';
+            }
+            down = false;
+        });
+    </script>
+</body>
+</html>

--- a/lib/integration-tests/tests/set-viewport/index.html
+++ b/lib/integration-tests/tests/set-viewport/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Set Viewport Test</title>
+</head>
+<body>
+    <h1>Set Viewport Test</h1>
+    <div id="size">0x0</div>
+    <script>
+        const sizeElement = document.getElementById('size');
+        function update() {
+            sizeElement.textContent = `${window.innerWidth}x${window.innerHeight}`;
+        }
+        update();
+        window.addEventListener('resize', update);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Adds two new native `BrowserAction` variants:

  - **`MouseDrag { from, to, steps, delayMillis }`** - left-button drag
  via `Input.dispatchMouseEvent` (Pressed -> N x Moved -> Released),
  interpolated along the line.
  
  - **`SetViewport { width, height }`** - runtime viewport change via
  `Emulation.setDeviceMetricsOverride`.



  Wired through the existing pipeline: `BrowserAction` -> `JsAction` (with
   bounds validation) -> CDP dispatch -> trace schema -> TS `Action` union ->
   CLI/Inspect renderers.