### PR TITLE
fix: correct timeline tick label scaling (#171)

### DIFF
--- a/lib/bombadil-inspect/src/timeline.rs
+++ b/lib/bombadil-inspect/src/timeline.rs
@@ -270,6 +270,7 @@ pub fn Timeline(
                         height={TIMESCALE_HEIGHT}
                         series={data.series_violations.clone()}
                         x_max={x_max}
+                        x_max_time={Duration::from_micros(x_max as u64)}
                         />
                 </g>
 
@@ -380,6 +381,7 @@ pub struct TimescaleProps {
     width: f64,
     height: f64,
     x_max: f64,
+    x_max_time: Duration,
 }
 
 #[component]
@@ -395,12 +397,11 @@ pub fn Timescale(props: &TimescaleProps) -> Html {
                     html!(
                         <>
                             <polyline class="border" points={format!(" {x},{top} {x},{bottom} ", top=TIMESCALE_VIOLATIONS_HEIGHT, bottom=TIMESCALE_VIOLATIONS_HEIGHT + TIMESCALE_TICK_HEIGHT)} />
-                            // TODO: pass in Durations rather than f64 for time
                             <text
                                 class="time-label"
                                 x={format!("{x}")}
                                 y={format!("{top}", top=TIMESCALE_VIOLATIONS_HEIGHT + TIMESCALE_TICK_HEIGHT * 2.0 + TIMESCALE_TEXT_HEIGHT / 2.0)}>
-                                {format_duration(Duration::from_millis((props.x_max * tick) as u64), FormatDurationOptions { include_millis: false })}
+                                {tick_label(props.x_max_time, *tick)}
                             </text>
                         </>
                     )
@@ -426,6 +427,17 @@ pub fn Timescale(props: &TimescaleProps) -> Html {
         }
         </g>
     </g>
+    )
+}
+
+/// Render a timescale tick label: the duration at `tick` (a 0.0..=1.0
+/// fraction) of the axis whose far end is `max`.
+fn tick_label(max: Duration, tick: f64) -> String {
+    format_duration(
+        max.mul_f64(tick),
+        FormatDurationOptions {
+            include_millis: true,
+        },
     )
 }
 

--- a/lib/bombadil-inspect/src/timeline.rs
+++ b/lib/bombadil-inspect/src/timeline.rs
@@ -401,7 +401,7 @@ pub fn Timescale(props: &TimescaleProps) -> Html {
                                 class="time-label"
                                 x={format!("{x}")}
                                 y={format!("{top}", top=TIMESCALE_VIOLATIONS_HEIGHT + TIMESCALE_TICK_HEIGHT * 2.0 + TIMESCALE_TEXT_HEIGHT / 2.0)}>
-                                {tick_label(props.x_max_time, *tick)}
+                                {format_duration(props.x_max_time.mul_f64(*tick), FormatDurationOptions { include_millis: false })}
                             </text>
                         </>
                     )
@@ -427,17 +427,6 @@ pub fn Timescale(props: &TimescaleProps) -> Html {
         }
         </g>
     </g>
-    )
-}
-
-/// Render a timescale tick label: the duration at `tick` (a 0.0..=1.0
-/// fraction) of the axis whose far end is `max`.
-fn tick_label(max: Duration, tick: f64) -> String {
-    format_duration(
-        max.mul_f64(tick),
-        FormatDurationOptions {
-            include_millis: true,
-        },
     )
 }
 

--- a/lib/bombadil-inspect/test/inspect.spec.ts
+++ b/lib/bombadil-inspect/test/inspect.spec.ts
@@ -60,9 +60,28 @@ const chartSpan = extract((state) => {
   };
 });
 
+const tickLabels = extract((state) =>
+  [...state.document.querySelectorAll(".timescale .time-label")].map(
+    (element) => element.textContent,
+  ),
+);
+
 export const eventuallyShowsActions = always(
   eventually(() => actionEntries.current.length > 0).within(2, "seconds"),
 );
+
+// Regression guard for #171: the timeline axis must span exactly the action
+// times. The first tick is the chart origin (00:00.000) and the last tick is
+// the final action's timestamp. A unit mismatch (micros rendered as millis)
+// scaled the labels by 1000x, which this property catches.
+export const timelineTicksMatchActionTimes = always(() => {
+  if (isLoading()) return true;
+  const ticks = tickLabels.current;
+  const entries = actionEntries.current;
+  if (!ticks?.length || entries.length === 0) return true;
+  const lastActionTime = entries[entries.length - 1].time;
+  return ticks[0] === "00:00.000" && ticks[ticks.length - 1] === lastActionTime;
+});
 
 export const clickTimelineMovesCursorCorrectly = always(() => {
   // Make sure we have a click and a timeline.

--- a/lib/bombadil-inspect/test/inspect.spec.ts
+++ b/lib/bombadil-inspect/test/inspect.spec.ts
@@ -71,16 +71,18 @@ export const eventuallyShowsActions = always(
 );
 
 // Regression guard for #171: the timeline axis must span exactly the action
-// times. The first tick is the chart origin (00:00.000) and the last tick is
-// the final action's timestamp. A unit mismatch (micros rendered as millis)
-// scaled the labels by 1000x, which this property catches.
+// times. The first tick is the chart origin (00:00) and the last tick is the
+// final action's timestamp. Tick labels omit milliseconds, so only the
+// non-fractional part of the action timestamp is compared. A unit mismatch
+// (micros rendered as millis) scaled the labels by 1000x, which this
+// property catches.
 export const timelineTicksMatchActionTimes = always(() => {
   if (isLoading()) return true;
   const ticks = tickLabels.current;
   const entries = actionEntries.current;
   if (!ticks?.length || entries.length === 0) return true;
-  const lastActionTime = entries[entries.length - 1].time;
-  return ticks[0] === "00:00.000" && ticks[ticks.length - 1] === lastActionTime;
+  const lastActionTime = entries[entries.length - 1]?.time?.split(".")[0];
+  return ticks[0] === "00:00" && ticks[ticks.length - 1] === lastActionTime;
 });
 
 export const clickTimelineMovesCursorCorrectly = always(() => {


### PR DESCRIPTION
## Summary

Resolves #171

The timeline axis tick labels were off by 1000x from the action list. The axis x-values are in microseconds, but the labels were rendered with `Duration::from_millis`, so an action at `00:00.156` showed up as `00:02:36` on the axis.

### Changes
- `Timescale` now receives the axis maximum as a `Duration` (`x_max_time`) and computes each tick label with `Duration::mul_f64`, so the time unit is part of the type. This also removes the old `// TODO: pass in Durations rather than f64 for time`.
- Tick labels keep omitting milliseconds to stay compact, so they match the non-fractional part of the action-list timestamps.

## Testing
- Added the inspect-spec property `timelineTicksMatchActionTimes`: the first tick must be the chart origin (`00:00`) and the last tick must equal the final action's timestamp, compared without the fractional part since ticks don't show milliseconds.
- Ran a self-test loop in the nix dev shell:
<details>
<summary>Exact commands</summary>

```bash
# Build the binary (also builds and embeds the inspect WASM via trunk)
nix develop -c cargo build -p bombadil-cli

# Generate a report to inspect
nix develop -c ./target/debug/bombadil browser test lib/bombadil-browser-integration-tests/tests/console-error/index.html --headless --output-path report --exit-on-violation --time-limit 30s

# Serve the report and run the inspect UI self-test against it
nix develop -c bash -c '
  ./target/debug/bombadil browser inspect report --no-open --port 1073 &
  SERVER=$!
  for i in $(seq 1 30); do curl -sf http://localhost:1073 >/dev/null 2>&1 && break; sleep 1; done
  ./target/debug/bombadil browser test --headless --instrument-javascript="" --output-path inspect-test-output --time-limit 1m http://localhost:1073 lib/bombadil-inspect/test/inspect.spec.ts
  kill $SERVER 2>/dev/null
'
```
</details>

- Confirmed in the inspect UI (2-minute run, 1929 actions) that the last action's timestamp matches the final axis tick:
  <img width="3006" height="528" alt="x-axis-time" src="https://github.com/user-attachments/assets/294467ce-0aa9-4241-9521-3cd8d63dab19" />



  