### PR TITLE
browser: only emit text for text-producing keys

### DIFF
--- a/lib/bombadil-browser-keys/src/lib.rs
+++ b/lib/bombadil-browser-keys/src/lib.rs
@@ -1,3 +1,18 @@
+/// Returns the text a key produces when pressed, or `None` if it produces none.
+///
+/// Control and navigation keys — `Backspace`, `Tab`, `Escape`, the arrows, the
+/// function keys, and so on — produce no text.
+pub fn key_text(code: u8) -> Option<&'static str> {
+    match code {
+        13 => Some("\r"),
+        32 => Some(" "),
+        48..=57 | 65..=90 | 186..=192 | 219..=222 => key_name(code),
+        _ => None,
+    }
+}
+
+/// Returns the DOM `key` value for a keyboard event, e.g. `"c"`, `"Enter"`, or
+/// `"Backspace"`, or `None` for an unrecognized key code.
 pub fn key_name(code: u8) -> Option<&'static str> {
     match code {
         8 => Some("Backspace"),
@@ -84,5 +99,31 @@ pub fn key_name(code: u8) -> Option<&'static str> {
         221 => Some("]"),
         222 => Some("'"),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enter_produces_carriage_return() {
+        assert_eq!(key_text(13), Some("\r"));
+    }
+
+    #[test]
+    fn printable_keys_produce_their_character() {
+        assert_eq!(key_text(67), Some("c"));
+        assert_eq!(key_text(48), Some("0"));
+        assert_eq!(key_text(32), Some(" "));
+        assert_eq!(key_text(188), Some(","));
+        assert_eq!(key_text(222), Some("'"));
+    }
+
+    #[test]
+    fn control_and_navigation_keys_produce_no_text() {
+        for code in [8, 9, 16, 27, 37, 38, 39, 40, 46, 112] {
+            assert_eq!(key_text(code), None, "code {code} should produce no text");
+        }
     }
 }

--- a/lib/bombadil-browser/src/browser/actions.rs
+++ b/lib/bombadil-browser/src/browser/actions.rs
@@ -10,7 +10,7 @@ use tokio::time::sleep;
 
 use crate::geometry::Point;
 use crate::js_action::JsAction;
-use bombadil_browser_keys::key_name;
+use bombadil_browser_keys::{key_name, key_text};
 
 #[derive(Clone, Copy, Debug)]
 pub struct ActionOptions {
@@ -161,30 +161,40 @@ impl BrowserAction {
                 }
             }
             BrowserAction::PressKey { code } => {
-                let build_params = |event_type| {
-                    if let Some(name) = key_name(*code) {
+                let Some(name) = key_name(*code) else {
+                    bail!("unknown key with code: {:?}", code);
+                };
+                let text = key_text(*code);
+                let build_params = |event_type, text: Option<&str>| {
+                    let mut builder =
                         input::DispatchKeyEventParams::builder()
                             .r#type(event_type)
                             .native_virtual_key_code(*code as i64)
                             .windows_virtual_key_code(*code as i64)
                             .code(name)
-                            .key(name)
-                            .unmodified_text("\r")
-                            .text("\r")
-                            .build()
-                            .map_err(|err| anyhow!(err))
-                    } else {
-                        bail!("unknown key with code: {:?}", code)
+                            .key(name);
+                    if let Some(text) = text {
+                        builder = builder.unmodified_text(text).text(text);
                     }
+                    builder.build().map_err(|err| anyhow!(err))
                 };
                 page.execute(build_params(
                     input::DispatchKeyEventType::RawKeyDown,
+                    None,
                 )?)
                 .await?;
-                page.execute(build_params(input::DispatchKeyEventType::Char)?)
+                if let Some(text) = text {
+                    page.execute(build_params(
+                        input::DispatchKeyEventType::Char,
+                        Some(text),
+                    )?)
                     .await?;
-                page.execute(build_params(input::DispatchKeyEventType::KeyUp)?)
-                    .await?;
+                }
+                page.execute(build_params(
+                    input::DispatchKeyEventType::KeyUp,
+                    None,
+                )?)
+                .await?;
             }
             BrowserAction::SetFileInputFiles { selector, files } => {
                 let document =

--- a/lib/integration-tests/tests/integration_tests.rs
+++ b/lib/integration-tests/tests/integration_tests.rs
@@ -546,6 +546,30 @@ export const inputEventuallyHasText = eventually(
 }
 
 #[tokio::test]
+async fn test_textarea_backspace() {
+    BrowserIntegrationTest::new("textarea-backspace")
+        .specification(
+            r#"
+import { eventually } from "@antithesishq/bombadil";
+import { actions, extract } from "@antithesishq/bombadil/browser";
+
+export const backspaces = actions(() => [{ PressKey: { code: 8 } }]);
+
+const editorValue = extract((state) => {
+  const editor = state.document.querySelector("\#editor");
+  return editor ? editor.value : "";
+});
+
+export const editorEventuallyEmpty = eventually(
+  () => editorValue.current === ""
+).within(10, "seconds");
+"#,
+        )
+        .run()
+        .await;
+}
+
+#[tokio::test]
 async fn test_counter_state_machine() {
     BrowserIntegrationTest::new("counter-state-machine")
         .time_limit(Duration::from_secs(3))

--- a/lib/integration-tests/tests/textarea-backspace/index.html
+++ b/lib/integration-tests/tests/textarea-backspace/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Textarea Backspace</title>
+</head>
+<body>
+    <h1>Textarea Backspace Test</h1>
+    <p>Press Backspace to empty the textarea below:</p>
+    <textarea id="editor" autofocus rows="4" cols="40">hello</textarea>
+
+    <script>
+        const editor = document.getElementById('editor');
+        editor.focus();
+        editor.setSelectionRange(editor.value.length, editor.value.length);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Needed this snippet for testing a diff viewer. I'm kinda new to this codebase, so I relied on Claude, but I can vouch for the changes here.