### PR TITLE
Add custom actions support

### DIFF
--- a/lib/bombadil-browser-integration-tests/tests/custom-action/index.html
+++ b/lib/bombadil-browser-integration-tests/tests/custom-action/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Custom Action Test</title>
+  </head>
+  <body>
+    <h1>Custom Action Test</h1>
+    <div id="counter">5</div>
+    <div id="result"></div>
+  </body>
+</html>

--- a/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
+++ b/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
@@ -1100,3 +1100,45 @@ export const eventuallyDone = eventually(() => isDone.current);
         .run()
         .await;
 }
+
+#[tokio::test]
+async fn test_custom_action() {
+    BrowserIntegrationTest::new("custom-action")
+        .time_limit(Duration::from_secs(5))
+        .specification(
+            r##"
+import { eventually } from "@antithesishq/bombadil";
+import { actions, extract, registerCustomAction } from "@antithesishq/bombadil/browser";
+
+const counter = extract((state) => {
+  const element = state.document.getElementById("counter");
+  return parseInt(element?.textContent ?? "0", 10);
+});
+
+const result = extract((state) => {
+  const element = state.document.getElementById("result");
+  return element?.textContent ?? "";
+});
+
+registerCustomAction("doubleCounter", async () => {
+  const resultElement = document.getElementById("result");
+  if (resultElement) {
+    resultElement.textContent = (counter.current * 2).toString();
+  }
+});
+
+export const _actions = actions(() => {
+  if (result.current === "") {
+    return [{ Custom: { name: "doubleCounter" } }];
+  }
+  return ["Wait"];
+});
+
+export const counterDoubled = eventually(() =>
+  result.current === "10"
+).within(5, "seconds");
+"##,
+        )
+        .run()
+        .await;
+}

--- a/lib/bombadil-browser/src/browser/actions.rs
+++ b/lib/bombadil-browser/src/browser/actions.rs
@@ -302,13 +302,17 @@ impl BrowserAction {
             BrowserAction::Custom { name, state } => {
                 let state_stringified = json::to_string(state)?;
 
-                page.evaluate(format!(r#"(() => {{
+                page.evaluate(format!(r#"(async () => {{
                     const state = JSON.parse('{state_stringified}');
                     const action = __bombadilRequire('@antithesishq/bombadil').runtime.customActions["{name}"];
                     if (!action) {{
                         throw new Error("Custom action {name} not found");
                     }}
-                    action.run({{ ...state, document, window }});
+                    try {{
+                        await action.run({{ ...state, document, window }});
+                    }} catch (err) {{
+                        throw new Error(`Error executing custom action {name}: ${{err}}`);
+                    }}
                 }})()"#)).await?;
             }
         };
@@ -387,6 +391,10 @@ impl BrowserActionTemplate {
                     height: rng.random_range(height.clone()),
                 }
             }
+            BrowserAction::Custom { name, state } => BrowserAction::Custom {
+                name: name.clone(),
+                state: state.clone(),
+            },
         }
     }
 

--- a/lib/bombadil-browser/src/browser/actions.rs
+++ b/lib/bombadil-browser/src/browser/actions.rs
@@ -65,6 +65,10 @@ pub enum BrowserAction<U8 = u8, U16 = u16, U64 = u64, F64 = f64, Text = String>
         width: U16,
         height: U16,
     },
+    Custom {
+        name: String,
+        state: json::Value,
+    },
 }
 
 pub type BrowserActionTemplate = BrowserAction<
@@ -294,6 +298,18 @@ impl BrowserAction {
                         .map_err(|err| anyhow!(err))?,
                 )
                 .await?;
+            }
+            BrowserAction::Custom { name, state } => {
+                let state_stringified = json::to_string(state)?;
+
+                page.evaluate(format!(r#"(() => {{
+                    const state = JSON.parse('{state_stringified}');
+                    const action = __bombadilRequire('@antithesishq/bombadil').runtime.customActions["{name}"];
+                    if (!action) {{
+                        throw new Error("Custom action {name} not found");
+                    }}
+                    action.run({{ ...state, document, window }});
+                }})()"#)).await?;
             }
         };
         Ok(())

--- a/lib/bombadil-browser/src/browser/actions.rs
+++ b/lib/bombadil-browser/src/browser/actions.rs
@@ -67,7 +67,6 @@ pub enum BrowserAction<U8 = u8, U16 = u16, U64 = u64, F64 = f64, Text = String>
     },
     Custom {
         name: String,
-        state: json::Value,
     },
 }
 
@@ -299,17 +298,10 @@ impl BrowserAction {
                 )
                 .await?;
             }
-            BrowserAction::Custom { name, state } => {
-                let state_stringified = json::to_string(state)?;
-
+            BrowserAction::Custom { name } => {
                 page.evaluate(format!(r#"(async () => {{
-                    const state = JSON.parse('{state_stringified}');
-                    const action = __bombadilRequire('@antithesishq/bombadil').runtime.customActions["{name}"];
-                    if (!action) {{
-                        throw new Error("Custom action {name} not found");
-                    }}
                     try {{
-                        await action.run({{ ...state, document, window }});
+                        await __bombadilRequire('@antithesishq/bombadil').runtime.runCustomAction('{name}');
                     }} catch (err) {{
                         throw new Error(`Error executing custom action {name}: ${{err}}`);
                     }}
@@ -391,10 +383,9 @@ impl BrowserActionTemplate {
                     height: rng.random_range(height.clone()),
                 }
             }
-            BrowserAction::Custom { name, state } => BrowserAction::Custom {
-                name: name.clone(),
-                state: state.clone(),
-            },
+            BrowserAction::Custom { name } => {
+                BrowserAction::Custom { name: name.clone() }
+            }
         }
     }
 

--- a/lib/bombadil-browser/src/convert.rs
+++ b/lib/bombadil-browser/src/convert.rs
@@ -100,6 +100,12 @@ impl ToSchema<browser::BrowserAction> for BrowserAction {
                     height: *height,
                 }
             }
+            BrowserAction::Custom { name, state } => {
+                browser::BrowserAction::Custom {
+                    name: name.clone(),
+                    state: state.clone(),
+                }
+            }
         }
     }
 }
@@ -168,6 +174,12 @@ impl ToInternal<BrowserAction> for browser::BrowserAction {
                 BrowserAction::SetViewport {
                     width: *width,
                     height: *height,
+                }
+            }
+            browser::BrowserAction::Custom { name, state } => {
+                BrowserAction::Custom {
+                    name: name.clone(),
+                    state: state.clone(),
                 }
             }
         }

--- a/lib/bombadil-browser/src/convert.rs
+++ b/lib/bombadil-browser/src/convert.rs
@@ -100,11 +100,8 @@ impl ToSchema<browser::BrowserAction> for BrowserAction {
                     height: *height,
                 }
             }
-            BrowserAction::Custom { name, state } => {
-                browser::BrowserAction::Custom {
-                    name: name.clone(),
-                    state: state.clone(),
-                }
+            BrowserAction::Custom { name } => {
+                browser::BrowserAction::Custom { name: name.clone() }
             }
         }
     }
@@ -176,11 +173,8 @@ impl ToInternal<BrowserAction> for browser::BrowserAction {
                     height: *height,
                 }
             }
-            browser::BrowserAction::Custom { name, state } => {
-                BrowserAction::Custom {
-                    name: name.clone(),
-                    state: state.clone(),
-                }
+            browser::BrowserAction::Custom { name } => {
+                BrowserAction::Custom { name: name.clone() }
             }
         }
     }

--- a/lib/bombadil-browser/src/driver.rs
+++ b/lib/bombadil-browser/src/driver.rs
@@ -317,7 +317,20 @@ async fn run_extractors(
 
     let partial_snapshots: Vec<PartialSnapshot> = state
             .evaluate_function_call(
-                "(state) => __bombadilRequire('@antithesishq/bombadil').runtime.runExtractors({ ...state, document, window })",
+                r#"(state) => {
+                    const runtime = __bombadilRequire('@antithesishq/bombadil').runtime;
+                    const snapshots = runtime.runExtractors({ ...state, document, window });
+
+                    // Update extractor cells in browser context
+                    snapshots.forEach((snapshot, index) => {
+                        const extractor = runtime.extractors[index];
+                        if (extractor) {
+                            extractor.update(snapshot.value);
+                        }
+                    });
+
+                    return snapshots;
+                }"#,
                 vec![state_partial.clone()],
             )
             .await?;

--- a/lib/bombadil-browser/src/driver.rs
+++ b/lib/bombadil-browser/src/driver.rs
@@ -317,21 +317,8 @@ async fn run_extractors(
 
     let partial_snapshots: Vec<PartialSnapshot> = state
             .evaluate_function_call(
-                r#"(state) => {
-                    const runtime = __bombadilRequire('@antithesishq/bombadil').runtime;
-                    const snapshots = runtime.runExtractors({ ...state, document, window });
-
-                    // Update extractor cells in browser context
-                    snapshots.forEach((snapshot, index) => {
-                        const extractor = runtime.extractors[index];
-                        if (extractor) {
-                            extractor.update(snapshot.value);
-                        }
-                    });
-
-                    return snapshots;
-                }"#,
-                vec![state_partial.clone()],
+                "(state) => __bombadilRequire('@antithesishq/bombadil').runtime.runExtractors({ ...state, document, window })",
+                vec![state_partial.clone()]
             )
             .await?;
 

--- a/lib/bombadil-browser/src/js_action.rs
+++ b/lib/bombadil-browser/src/js_action.rs
@@ -64,6 +64,9 @@ pub enum JsAction {
         width: JsRange,
         height: JsRange,
     },
+    Custom {
+        name: String,
+    },
 }
 
 impl TryInto<BrowserActionTemplate> for JsAction {
@@ -175,6 +178,13 @@ impl TryInto<BrowserActionTemplate> for JsAction {
                 }
                 BrowserAction::SetViewport { width, height }
             }
+            JsAction::Custom { name } => BrowserAction::Custom {
+                name,
+                // State is set to an empty object currently,
+                // this is passed as an argument to the custom action function
+                // can be used later when implemented.
+                state: serde_json::Value::Object(serde_json::Map::new()),
+            },
         })
     }
 }

--- a/lib/bombadil-browser/src/js_action.rs
+++ b/lib/bombadil-browser/src/js_action.rs
@@ -178,13 +178,7 @@ impl TryInto<BrowserActionTemplate> for JsAction {
                 }
                 BrowserAction::SetViewport { width, height }
             }
-            JsAction::Custom { name } => BrowserAction::Custom {
-                name,
-                // State is set to an empty object currently,
-                // this is passed as an argument to the custom action function
-                // can be used later when implemented.
-                state: serde_json::Value::Object(serde_json::Map::new()),
-            },
+            JsAction::Custom { name } => BrowserAction::Custom { name },
         })
     }
 }

--- a/lib/bombadil-browser/src/render.rs
+++ b/lib/bombadil-browser/src/render.rs
@@ -224,5 +224,12 @@ pub fn format_action<
                 styled::maybe_blue(format!("{}", Formatted(height)))
             )
         }
+        BrowserAction::Custom { name, state } => {
+            format!(
+                "{} <{name}> with state: {}",
+                styled::maybe_bold("Performing custom action".to_string()),
+                styled::maybe_blue(format!("{:?}", state))
+            )
+        }
     }
 }

--- a/lib/bombadil-browser/src/render.rs
+++ b/lib/bombadil-browser/src/render.rs
@@ -224,11 +224,10 @@ pub fn format_action<
                 styled::maybe_blue(format!("{}", Formatted(height)))
             )
         }
-        BrowserAction::Custom { name, state } => {
+        BrowserAction::Custom { name } => {
             format!(
-                "{} <{name}> with state: {}",
-                styled::maybe_bold("Performing custom action".to_string()),
-                styled::maybe_blue(format!("{:?}", state))
+                "{} <{name}>",
+                styled::maybe_bold("Performing custom action".to_string())
             )
         }
     }

--- a/lib/bombadil-inspect/src/actions.rs
+++ b/lib/bombadil-inspect/src/actions.rs
@@ -180,6 +180,13 @@ fn ActionEntry(props: &HistoryEntryProps) -> Html {
                     html!(<span class="action-name">{"Set viewport"}</span>),
                     Some(vec![("Size", format!("{width}x{height}"))]),
                 ),
+                BrowserAction::Custom { name, state } => (
+                    html!(<span class="action-name">{"Custom action"}</span>),
+                    Some(vec![
+                        ("Name", name.clone()),
+                        ("State", format!("{:?}", state)),
+                    ]),
+                ),
             },
             None => return html! {},
         };

--- a/lib/bombadil-inspect/src/actions.rs
+++ b/lib/bombadil-inspect/src/actions.rs
@@ -180,12 +180,9 @@ fn ActionEntry(props: &HistoryEntryProps) -> Html {
                     html!(<span class="action-name">{"Set viewport"}</span>),
                     Some(vec![("Size", format!("{width}x{height}"))]),
                 ),
-                BrowserAction::Custom { name, state } => (
+                BrowserAction::Custom { name } => (
                     html!(<span class="action-name">{"Custom action"}</span>),
-                    Some(vec![
-                        ("Name", name.clone()),
-                        ("State", format!("{:?}", state)),
-                    ]),
+                    Some(vec![("Name", name.clone())]),
                 ),
             },
             None => return html! {},

--- a/lib/bombadil-schema/src/browser.rs
+++ b/lib/bombadil-schema/src/browser.rs
@@ -185,4 +185,8 @@ pub enum BrowserAction {
         width: u16,
         height: u16,
     },
+    Custom {
+        name: String,
+        state: serde_json::Value,
+    },
 }

--- a/lib/bombadil-schema/src/browser.rs
+++ b/lib/bombadil-schema/src/browser.rs
@@ -187,6 +187,5 @@ pub enum BrowserAction {
     },
     Custom {
         name: String,
-        state: serde_json::Value,
     },
 }

--- a/lib/bombadil/src/specification/browser/index.ts
+++ b/lib/bombadil/src/specification/browser/index.ts
@@ -200,7 +200,7 @@ function getStructuralPath(el: Element): string {
 
 export function registerCustomAction(
   name: string,
-  scriptFunction: (state: Pick<State, "document" | "window">) => void,
+  scriptFunction: (state: Pick<State, "document" | "window">) => Promise<void>,
 ) {
   bombadil.registerCustomAction<Pick<State, "document" | "window">>(
     name,

--- a/lib/bombadil/src/specification/browser/index.ts
+++ b/lib/bombadil/src/specification/browser/index.ts
@@ -39,7 +39,7 @@ export type Action<Number = number, String = string> =
       };
     }
   | { SetViewport: { width: Number; height: Number } }
-  | { Custom: { name: string } };
+  | { Custom: { name: string; state: Pick<State, "document" | "window"> } };
 
 export type ActionTemplate = Action<Range, StringGenerator>;
 

--- a/lib/bombadil/src/specification/browser/index.ts
+++ b/lib/bombadil/src/specification/browser/index.ts
@@ -38,7 +38,8 @@ export type Action<Number = number, String = string> =
         delayMillis: Number;
       };
     }
-  | { SetViewport: { width: Number; height: Number } };
+  | { SetViewport: { width: Number; height: Number } }
+  | { Custom: { name: string } };
 
 export type ActionTemplate = Action<Range, StringGenerator>;
 
@@ -134,9 +135,9 @@ export function getFingerprint(el: Element): Fingerprint {
   const accessibleName =
     el.getAttribute("aria-label") ??
     (el.getAttribute("aria-labelledby")
-      ? (document
+      ? document
           .getElementById(el.getAttribute("aria-labelledby")!)
-          ?.textContent?.trim() ?? null)
+          ?.textContent?.trim()
       : null) ??
     el.getAttribute("title");
 
@@ -195,4 +196,14 @@ function getStructuralPath(el: Element): string {
   }
 
   return parts.join(" > ");
+}
+
+export function registerCustomAction(
+  name: string,
+  scriptFunction: (state: Pick<State, "document" | "window">) => void,
+) {
+  bombadil.registerCustomAction<Pick<State, "document" | "window">>(
+    name,
+    scriptFunction,
+  );
 }

--- a/lib/bombadil/src/specification/browser/index.ts
+++ b/lib/bombadil/src/specification/browser/index.ts
@@ -39,7 +39,7 @@ export type Action<Number = number, String = string> =
       };
     }
   | { SetViewport: { width: Number; height: Number } }
-  | { Custom: { name: string; state: Pick<State, "document" | "window"> } };
+  | { Custom: { name: string } };
 
 export type ActionTemplate = Action<Range, StringGenerator>;
 
@@ -200,10 +200,7 @@ function getStructuralPath(el: Element): string {
 
 export function registerCustomAction(
   name: string,
-  scriptFunction: (state: Pick<State, "document" | "window">) => Promise<void>,
+  scriptFunction: () => Promise<void>,
 ) {
-  bombadil.registerCustomAction<Pick<State, "document" | "window">>(
-    name,
-    scriptFunction,
-  );
+  bombadil.registerCustomAction(name, scriptFunction);
 }

--- a/lib/bombadil/src/specification/index.ts
+++ b/lib/bombadil/src/specification/index.ts
@@ -1,14 +1,12 @@
 import {
+  CustomAction,
   ExtractorCell,
   Runtime,
   type JSON,
   type TimeUnit,
 } from "@antithesishq/bombadil/internal";
 
-import {
-  type ActionGenerator,
-  type Tree,
-} from "@antithesishq/bombadil/actions";
+import { ActionGenerator, type Tree } from "@antithesishq/bombadil/actions";
 import * as bombadilActions from "@antithesishq/bombadil/actions";
 
 export { type Cell, type JSON } from "@antithesishq/bombadil/internal";
@@ -28,16 +26,20 @@ export const runtime = new Runtime<unknown>();
 export function extract<S, T extends JSON>(
   query: (state: S) => T,
 ): ExtractorCell<T, S> {
-  return new ExtractorCell<T, unknown>(
-    runtime,
-    query as (state: unknown) => T,
-  );
+  return new ExtractorCell<T, unknown>(runtime, query as (state: unknown) => T);
 }
 
-export function actions<A>(
-  generate: () => Tree<A> | A[],
-): ActionGenerator<A> {
+export function actions<A>(generate: () => Tree<A> | A[]): ActionGenerator<A> {
   return bombadilActions.actions(generate);
+}
+
+export function registerCustomAction<S>(
+  name: string,
+  scriptFunction: (state: S) => void,
+) {
+  runtime.registerCustomAction(
+    new CustomAction(name, scriptFunction) as CustomAction<unknown>,
+  );
 }
 
 export function weighted<A>(

--- a/lib/bombadil/src/specification/index.ts
+++ b/lib/bombadil/src/specification/index.ts
@@ -13,10 +13,7 @@ import {
 } from "@antithesishq/bombadil/actions";
 
 export { type Cell, type JSON } from "@antithesishq/bombadil/internal";
-export {
-  ActionGenerator,
-  type Tree,
-} from "@antithesishq/bombadil/actions";
+export { ActionGenerator, type Tree } from "@antithesishq/bombadil/actions";
 
 /**
  * The runtime singleton that all `extract` calls register into and that
@@ -38,7 +35,7 @@ export function actions<A>(generate: () => Tree<A> | A[]): ActionGenerator<A> {
 
 export function registerCustomAction<S>(
   name: string,
-  scriptFunction: (state: S) => void,
+  scriptFunction: (state: S) => Promise<void>,
 ) {
   runtime.registerCustomAction(
     new CustomAction(name, scriptFunction) as CustomAction<unknown>,

--- a/lib/bombadil/src/specification/index.ts
+++ b/lib/bombadil/src/specification/index.ts
@@ -6,8 +6,11 @@ import {
   type TimeUnit,
 } from "@antithesishq/bombadil/internal";
 
-import { ActionGenerator, type Tree } from "@antithesishq/bombadil/actions";
 import * as bombadilActions from "@antithesishq/bombadil/actions";
+import {
+  type Tree,
+  type ActionGenerator,
+} from "@antithesishq/bombadil/actions";
 
 export { type Cell, type JSON } from "@antithesishq/bombadil/internal";
 export {

--- a/lib/bombadil/src/specification/index.ts
+++ b/lib/bombadil/src/specification/index.ts
@@ -33,13 +33,11 @@ export function actions<A>(generate: () => Tree<A> | A[]): ActionGenerator<A> {
   return bombadilActions.actions(generate);
 }
 
-export function registerCustomAction<S>(
+export function registerCustomAction(
   name: string,
-  scriptFunction: (state: S) => Promise<void>,
+  scriptFunction: () => Promise<void>,
 ) {
-  runtime.registerCustomAction(
-    new CustomAction(name, scriptFunction) as CustomAction<unknown>,
-  );
+  runtime.registerCustomAction(new CustomAction(name, scriptFunction));
 }
 
 export function weighted<A>(

--- a/lib/bombadil/src/specification/internal.ts
+++ b/lib/bombadil/src/specification/internal.ts
@@ -52,11 +52,20 @@ export class ExtractorCell<T extends JSON, S> implements Cell<T> {
   }
 }
 
+export class CustomAction<S> {
+  constructor(
+    public name: string,
+    public run: (state: S) => void,
+  ) {}
+}
+
 export class Runtime<S> {
   extractors: ExtractorCell<any, S>[] = [];
   private extractingDepth: number = 0;
   private tracking = false;
   private accesses = new Set<number>();
+
+  customActions: Record<string, CustomAction<S>> = {};
 
   registerExtractor(cell: ExtractorCell<any, S>): number {
     const index = this.extractors.length;
@@ -107,5 +116,9 @@ export class Runtime<S> {
           "Use shared helper functions to avoid duplication.",
       );
     }
+  }
+
+  registerCustomAction(action: CustomAction<S>) {
+    this.customActions[action.name] = action;
   }
 }

--- a/lib/bombadil/src/specification/internal.ts
+++ b/lib/bombadil/src/specification/internal.ts
@@ -52,12 +52,18 @@ export class ExtractorCell<T extends JSON, S> implements Cell<T> {
   }
 }
 
-export class CustomAction<S> {
+export class CustomAction {
   constructor(
     public name: string,
-    public run: (state: S) => void,
+    public run: () => Promise<void>,
   ) {}
 }
+
+type RunExtractorsResult = {
+  index: number;
+  name: string | null;
+  value: JSON;
+}[];
 
 export class Runtime<S> {
   extractors: ExtractorCell<any, S>[] = [];
@@ -65,7 +71,7 @@ export class Runtime<S> {
   private tracking = false;
   private accesses = new Set<number>();
 
-  customActions: Record<string, CustomAction<S>> = {};
+  customActions: Record<string, CustomAction> = {};
 
   registerExtractor(cell: ExtractorCell<any, S>): number {
     const index = this.extractors.length;
@@ -91,21 +97,26 @@ export class Runtime<S> {
     }
   }
 
-  runExtractors(
-    state: S,
-  ): { index: number; name: string | null; value: JSON }[] {
-    return this.extractors.map((extractor, index) => {
+  runExtractors(state: S): RunExtractorsResult {
+    const snapshots: RunExtractorsResult = [];
+
+    this.extractors.forEach((extractor, index) => {
       this.extractingDepth++;
       try {
-        return {
+        const value = extractor.run(state);
+        extractor.update(value);
+
+        snapshots.push({
           index,
           name: extractor.name,
-          value: extractor.run(state),
-        };
+          value,
+        });
       } finally {
         this.extractingDepth--;
       }
     });
+
+    return snapshots;
   }
 
   checkNotExtracting(): void {
@@ -118,7 +129,15 @@ export class Runtime<S> {
     }
   }
 
-  registerCustomAction(action: CustomAction<S>) {
+  registerCustomAction(action: CustomAction) {
     this.customActions[action.name] = action;
+  }
+
+  async runCustomAction(name: string): Promise<void> {
+    const action = this.customActions[name];
+    if (!action) {
+      return Promise.reject(`Custom action '${name}' is not registered.`);
+    }
+    return action.run();
   }
 }

--- a/lib/bombadil/src/specification/internal.ts
+++ b/lib/bombadil/src/specification/internal.ts
@@ -59,11 +59,11 @@ export class CustomAction {
   ) {}
 }
 
-type RunExtractorsResult = {
+type RunExtractorResult = {
   index: number;
   name: string | null;
   value: JSON;
-}[];
+};
 
 export class Runtime<S> {
   extractors: ExtractorCell<any, S>[] = [];
@@ -97,8 +97,8 @@ export class Runtime<S> {
     }
   }
 
-  runExtractors(state: S): RunExtractorsResult {
-    const snapshots: RunExtractorsResult = [];
+  runExtractors(state: S): RunExtractorResult[] {
+    const snapshots: RunExtractorResult[] = [];
 
     this.extractors.forEach((extractor, index) => {
       this.extractingDepth++;


### PR DESCRIPTION
Closes: #128 

This PR adds custom actions capability which allows users to define custom functions that act as actions that run in the browser context.

Example:
```ts
const title = extract(state => state.document.title || "");

registerCustomAction("draw_title_on_canvas", () => {
  const canvas = document.querySelector("#my-canvas");
  const ctx = canvas.getContext("2d");

  ctx.font = "30px Arial"; 
  ctx.fillStyle = "black";

  ctx.fillText(title.current, 0, 0);
});

export const actions = actions(() => {
  return [{ Custom: { name: "draw_title_on_canvas" } }]
});
```

Notes:
* ~The `state` argument to the callback contains only the `window` and `document` objects and not the other details.~ The custom action function receives no arguments but can access the global window object.
* Action functions can close over extractor values and they get the latest value on each iteration