### PR TITLE
Add --cookie option for browser testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The Bombadil Changelog
 
+## Unreleased
+
+Major updates:
+
+* Add `--cookie NAME=VALUE` option to set real browser cookies before testing, scoped to the origin (useful for client-side auth flows that read cookies, unlike `--header`)
+
 ## 0.6.1
 
 # Major updates:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Major updates:
 
-* Add `--cookie NAME=VALUE` option to set real browser cookies before testing, scoped to the origin (useful for client-side auth flows that read cookies, unlike `--header`) (#232)
+* Add `--cookie NAME=VALUE` option to set real browser cookies before testing, scoped to the origin (useful for client-side auth flows that read cookies, unlike `--header`)
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Major updates:
 
-* Add `--cookie NAME=VALUE` option to set real browser cookies before testing, scoped to the origin (useful for client-side auth flows that read cookies, unlike `--header`)
+* Add `--cookie NAME=VALUE` option to set real browser cookies before testing, scoped to the origin (useful for client-side auth flows that read cookies, unlike `--header`) (#232)
 
 ## 0.6.1
 

--- a/docs/manual/src/04-reference.md
+++ b/docs/manual/src/04-reference.md
@@ -38,6 +38,7 @@
 | `--instrument-javascript <INSTRUMENT_JAVASCRIPT>` | What types of JavaScript to instrument for coverage tracking. Comma-separated list of: "files", "inline" | files,inline |
 | `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--header <KEY=VALUE>` | Extra HTTP header to send with all browser requests, in `KEY=VALUE format`. Can be specified multiple times. | |
+| `--cookie <NAME=VALUE>` | Cookie to set in the browser before testing, in `NAME=VALUE` format. Set as a real browser cookie scoped to the origin, unlike `--header` which only sends a static request header. Can be specified multiple times. | |
 | `--reproduce <TRACE_FILE>` | Reproduce a previous test run from a trace file, instead of random exploration. Mutually exclusive with `--time-limit` and `--exit-on-violation`. | |
 | `--headless` | Whether the browser should run in a visible window or not | |
 | `--no-sandbox` | Disable Chromium sandboxing | |
@@ -68,6 +69,7 @@
 | `--instrument-javascript <INSTRUMENT_JAVASCRIPT>` | What types of JavaScript to instrument for coverage tracking. Comma-separated list of: "files", "inline" | files,inline |
 | `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--header <KEY=VALUE>` | Extra HTTP header to send with all browser requests, in `KEY=VALUE format`. Can be specified multiple times. | |
+| `--cookie <NAME=VALUE>` | Cookie to set in the browser before testing, in `NAME=VALUE` format. Set as a real browser cookie scoped to the origin, unlike `--header` which only sends a static request header. Can be specified multiple times. | |
 | `--reproduce <TRACE_FILE>` | Reproduce a previous test run from a trace file, instead of random exploration. Mutually exclusive with `--time-limit` and `--exit-on-violation`. | |
 | `--remote-debugger <REMOTE_DEBUGGER>` | Address to the remote debugger's server, e.g. http://localhost:9222 | |
 | `--create-target` | Whether Bombadil should create a new tab and navigate to the origin URL in it, as part of starting the test (this should probably be false if you test an Electron app) | |

--- a/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
+++ b/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
@@ -76,6 +76,7 @@ struct BrowserIntegrationTest<'a> {
     specification: Option<&'a str>,
     grant_permissions: Vec<String>,
     extra_headers: HashMap<String, String>,
+    cookies: Vec<(String, String)>,
 }
 
 impl<'a> BrowserIntegrationTest<'a> {
@@ -88,6 +89,7 @@ impl<'a> BrowserIntegrationTest<'a> {
             specification: None,
             grant_permissions: vec![],
             extra_headers: HashMap::new(),
+            cookies: vec![],
         }
     }
 
@@ -122,6 +124,11 @@ impl<'a> BrowserIntegrationTest<'a> {
         self
     }
 
+    fn cookies(mut self, cookies: Vec<(String, String)>) -> Self {
+        self.cookies = cookies;
+        self
+    }
+
     /// Run a named browser test with a given expectation.
     ///
     /// Spins up two web servers: one on a random port P, and one on port P + 1, in order to
@@ -141,6 +148,7 @@ impl<'a> BrowserIntegrationTest<'a> {
             specification,
             grant_permissions,
             extra_headers,
+            cookies,
         } = self;
         setup();
         let _permit = TEST_SEMAPHORE.acquire().await.unwrap();
@@ -251,6 +259,7 @@ impl<'a> BrowserIntegrationTest<'a> {
             downloads_directory: downloads_directory.path().to_path_buf(),
             grant_permissions,
             extra_headers,
+            cookies,
         };
         let debugger_options = DebuggerOptions::Managed {
             launch_options: LaunchOptions {
@@ -506,6 +515,7 @@ async fn test_browser_lifecycle() {
             downloads_directory: downloads_directory.path().to_path_buf(),
             grant_permissions: vec![],
             extra_headers: Default::default(),
+            cookies: vec![],
         },
         DebuggerOptions::Managed {
             launch_options: LaunchOptions {
@@ -938,6 +948,30 @@ const loaded = extract((state) => {
 
 export const secretResourceLoaded = eventually(
   () => loaded.current === true
+).within(10, "seconds");
+"#,
+        )
+        .run()
+        .await;
+}
+
+#[tokio::test]
+async fn test_cookies() {
+    BrowserIntegrationTest::new("fetch-headers")
+        .cookies(vec![("session".to_string(), "bombadil".to_string())])
+        .time_limit(Duration::from_secs(15))
+        .specification(
+            r#"
+import { eventually } from "@antithesishq/bombadil";
+import { extract } from "@antithesishq/bombadil/browser";
+export { clicks } from "@antithesishq/bombadil/browser/defaults/actions";
+
+const cookieSet = extract((state) => {
+  return state.document.cookie.includes("session=bombadil");
+});
+
+export const sessionCookiePresent = eventually(
+  () => cookieSet.current === true
 ).within(10, "seconds");
 "#,
         )

--- a/lib/bombadil-browser/src/browser.rs
+++ b/lib/bombadil-browser/src/browser.rs
@@ -185,6 +185,7 @@ pub struct BrowserOptions {
     pub downloads_directory: PathBuf,
     pub grant_permissions: Vec<String>,
     pub extra_headers: HashMap<String, String>,
+    pub cookies: Vec<(String, String)>,
 }
 
 #[derive(Clone)]
@@ -271,6 +272,29 @@ impl Browser {
                 )?),
             ))
             .await?;
+        }
+
+        if !browser_options.cookies.is_empty() {
+            // Cookies are associated with the origin URL so that the
+            // browser derives an appropriate domain, path, and scheme.
+            // Unlike a static Cookie request header, these become real
+            // browser cookies and are sent on every navigation, which is
+            // what client-side auth flows (e.g. MSAL) rely on.
+            let cookies = browser_options
+                .cookies
+                .iter()
+                .map(|(name, value)| {
+                    network::CookieParam::builder()
+                        .name(name)
+                        .value(value)
+                        .url(origin.as_str())
+                        .build()
+                        .map_err(|s| {
+                            anyhow!(s).context("build CookieParam failed")
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            page.execute(network::SetCookiesParams::new(cookies)).await?;
         }
 
         // Prevent file downloads to avoid getting stuck

--- a/lib/bombadil-browser/src/browser.rs
+++ b/lib/bombadil-browser/src/browser.rs
@@ -294,7 +294,8 @@ impl Browser {
                         })
                 })
                 .collect::<Result<Vec<_>>>()?;
-            page.execute(network::SetCookiesParams::new(cookies)).await?;
+            page.execute(network::SetCookiesParams::new(cookies))
+                .await?;
         }
 
         // Prevent file downloads to avoid getting stuck

--- a/lib/bombadil-cli/src/browser.rs
+++ b/lib/bombadil-cli/src/browser.rs
@@ -120,6 +120,12 @@ pub struct TestSharedOptions {
     /// Can be specified multiple times.
     #[arg(long = "header", value_name = "KEY=VALUE", value_parser = parse_header)]
     pub headers: Vec<(String, String)>,
+    /// Cookie to set in the browser before testing, in NAME=VALUE format.
+    /// Set as a real browser cookie scoped to the origin (so client-side auth
+    /// flows that read cookies work), unlike --header which only sends a
+    /// static request header. Can be specified multiple times.
+    #[arg(long = "cookie", value_name = "NAME=VALUE", value_parser = parse_header)]
+    pub cookies: Vec<(String, String)>,
     /// Reproduce a previous test run from a trace file, instead of random exploration.
     /// Mutually exclusive with --time-limit and --exit-on-violation.
     #[arg(long, value_name = "TRACE_FILE", conflicts_with_all = ["time_limit", "exit_on_violation"])]
@@ -286,6 +292,7 @@ fn browser_options_from_shared(
             .filter(|s| !s.is_empty())
             .collect(),
         extra_headers: shared.headers.iter().cloned().collect(),
+        cookies: shared.cookies.clone(),
     }
 }
 
@@ -313,6 +320,9 @@ fn reproduce_command_args(
     }
     for (key, value) in &shared.headers {
         args.push(format!("--header {key}={value}"));
+    }
+    for (name, value) in &shared.cookies {
+        args.push(format!("--cookie {name}={value}"));
     }
     args
 }


### PR DESCRIPTION
Adds a `--cookie NAME=VALUE` CLI flag (repeatable) for `bombadil browser test`.

Unlike `--header`, cookies are set via CDP `Network.setCookies` scoped to the origin URL, so they behave as real browser cookies and are available to client-side auth flows that read `document.cookie` (e.g. MSAL).

## Changes

- CLI: `--cookie` flag on browser test commands, forwarded through reproduce args
- `bombadil-browser`: set cookies before navigation via `SetCookiesParams`
- Integration test: `test_cookies` verifies `document.cookie` contains the set value
- Manual reference docs and CHANGELOG (Unreleased)

## Checklist

- [x] CHANGELOG entry under Unreleased
- [x] Manual reference updated (`docs/manual/src/04-reference.md`)
- [x] Integration test added
- [x] fmt/clippy/tests — left to CI