### PR TITLE
Extend --cookie to accept Set-Cookie syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Major updates:
 
-* Add `--cookie NAME=VALUE` option to set real browser cookies before testing, scoped to the origin (useful for client-side auth flows that read cookies, unlike `--header`)
+* Add `--cookie-domain` option to scope `--cookie` values to a parent domain (e.g. `.example.com`), so cookies are shared across subdomains
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Major updates:
 
-* Add `--cookie-domain` option to scope `--cookie` values to a parent domain (e.g. `.example.com`), so cookies are shared across subdomains
+* Extend `--cookie` to accept Set-Cookie syntax (`NAME=VALUE; Domain=...; Path=...; Secure; HttpOnly`). Plain `NAME=VALUE` still scopes to the origin
 
 ## 0.6.1
 

--- a/docs/manual/src/04-reference.md
+++ b/docs/manual/src/04-reference.md
@@ -38,8 +38,7 @@
 | `--instrument-javascript <INSTRUMENT_JAVASCRIPT>` | What types of JavaScript to instrument for coverage tracking. Comma-separated list of: "files", "inline" | files,inline |
 | `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--header <KEY=VALUE>` | Extra HTTP header to send with all browser requests, in `KEY=VALUE format`. Can be specified multiple times. | |
-| `--cookie <NAME=VALUE>` | Cookie to set in the browser before testing, in `NAME=VALUE` format. By default scoped to the origin host; use with `--cookie-domain` for parent-domain cookies. Unlike `--header`, these become real browser cookies. Can be specified multiple times. | |
-| `--cookie-domain <DOMAIN>` | Domain to scope `--cookie` values to (e.g. `.example.com`), so cookies are sent on subdomains as well as the origin host. | |
+| `--cookie <SET-COOKIE>` | Cookie to set in the browser before testing. Plain `NAME=VALUE` scopes to the origin; Set-Cookie attributes (`Domain`, `Path`, `Secure`, `HttpOnly`) are supported. Unlike `--header`, these become real browser cookies. Can be specified multiple times. | |
 | `--reproduce <TRACE_FILE>` | Reproduce a previous test run from a trace file, instead of random exploration. Mutually exclusive with `--time-limit` and `--exit-on-violation`. | |
 | `--headless` | Whether the browser should run in a visible window or not | |
 | `--no-sandbox` | Disable Chromium sandboxing | |
@@ -70,8 +69,7 @@
 | `--instrument-javascript <INSTRUMENT_JAVASCRIPT>` | What types of JavaScript to instrument for coverage tracking. Comma-separated list of: "files", "inline" | files,inline |
 | `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--header <KEY=VALUE>` | Extra HTTP header to send with all browser requests, in `KEY=VALUE format`. Can be specified multiple times. | |
-| `--cookie <NAME=VALUE>` | Cookie to set in the browser before testing, in `NAME=VALUE` format. By default scoped to the origin host; use with `--cookie-domain` for parent-domain cookies. Unlike `--header`, these become real browser cookies. Can be specified multiple times. | |
-| `--cookie-domain <DOMAIN>` | Domain to scope `--cookie` values to (e.g. `.example.com`), so cookies are sent on subdomains as well as the origin host. | |
+| `--cookie <SET-COOKIE>` | Cookie to set in the browser before testing. Plain `NAME=VALUE` scopes to the origin; Set-Cookie attributes (`Domain`, `Path`, `Secure`, `HttpOnly`) are supported. Unlike `--header`, these become real browser cookies. Can be specified multiple times. | |
 | `--reproduce <TRACE_FILE>` | Reproduce a previous test run from a trace file, instead of random exploration. Mutually exclusive with `--time-limit` and `--exit-on-violation`. | |
 | `--remote-debugger <REMOTE_DEBUGGER>` | Address to the remote debugger's server, e.g. http://localhost:9222 | |
 | `--create-target` | Whether Bombadil should create a new tab and navigate to the origin URL in it, as part of starting the test (this should probably be false if you test an Electron app) | |

--- a/docs/manual/src/04-reference.md
+++ b/docs/manual/src/04-reference.md
@@ -38,7 +38,8 @@
 | `--instrument-javascript <INSTRUMENT_JAVASCRIPT>` | What types of JavaScript to instrument for coverage tracking. Comma-separated list of: "files", "inline" | files,inline |
 | `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--header <KEY=VALUE>` | Extra HTTP header to send with all browser requests, in `KEY=VALUE format`. Can be specified multiple times. | |
-| `--cookie <NAME=VALUE>` | Cookie to set in the browser before testing, in `NAME=VALUE` format. Set as a real browser cookie scoped to the origin, unlike `--header` which only sends a static request header. Can be specified multiple times. | |
+| `--cookie <NAME=VALUE>` | Cookie to set in the browser before testing, in `NAME=VALUE` format. By default scoped to the origin host; use with `--cookie-domain` for parent-domain cookies. Unlike `--header`, these become real browser cookies. Can be specified multiple times. | |
+| `--cookie-domain <DOMAIN>` | Domain to scope `--cookie` values to (e.g. `.example.com`), so cookies are sent on subdomains as well as the origin host. | |
 | `--reproduce <TRACE_FILE>` | Reproduce a previous test run from a trace file, instead of random exploration. Mutually exclusive with `--time-limit` and `--exit-on-violation`. | |
 | `--headless` | Whether the browser should run in a visible window or not | |
 | `--no-sandbox` | Disable Chromium sandboxing | |
@@ -69,7 +70,8 @@
 | `--instrument-javascript <INSTRUMENT_JAVASCRIPT>` | What types of JavaScript to instrument for coverage tracking. Comma-separated list of: "files", "inline" | files,inline |
 | `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--header <KEY=VALUE>` | Extra HTTP header to send with all browser requests, in `KEY=VALUE format`. Can be specified multiple times. | |
-| `--cookie <NAME=VALUE>` | Cookie to set in the browser before testing, in `NAME=VALUE` format. Set as a real browser cookie scoped to the origin, unlike `--header` which only sends a static request header. Can be specified multiple times. | |
+| `--cookie <NAME=VALUE>` | Cookie to set in the browser before testing, in `NAME=VALUE` format. By default scoped to the origin host; use with `--cookie-domain` for parent-domain cookies. Unlike `--header`, these become real browser cookies. Can be specified multiple times. | |
+| `--cookie-domain <DOMAIN>` | Domain to scope `--cookie` values to (e.g. `.example.com`), so cookies are sent on subdomains as well as the origin host. | |
 | `--reproduce <TRACE_FILE>` | Reproduce a previous test run from a trace file, instead of random exploration. Mutually exclusive with `--time-limit` and `--exit-on-violation`. | |
 | `--remote-debugger <REMOTE_DEBUGGER>` | Address to the remote debugger's server, e.g. http://localhost:9222 | |
 | `--create-target` | Whether Bombadil should create a new tab and navigate to the origin URL in it, as part of starting the test (this should probably be false if you test an Electron app) | |

--- a/lib/bombadil-browser-integration-tests/tests/cookie-domain/check.html
+++ b/lib/bombadil-browser-integration-tests/tests/cookie-domain/check.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Cookie domain check</title>
+    </head>
+  <body>
+    <div id="cookie-ok" hidden>ok</div>
+    <script>
+      if (document.cookie.includes("session=bombadil")) {
+        document.getElementById("cookie-ok").hidden = false;
+      }
+    </script>
+  </body>
+</html>

--- a/lib/bombadil-browser-integration-tests/tests/cookie-domain/index.html
+++ b/lib/bombadil-browser-integration-tests/tests/cookie-domain/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Cookie domain</title>
+    <style>
+      button {
+        display: block;
+        padding: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <button>Visit other port</button>
+    <script>
+      document.querySelector("button").addEventListener("click", () => {
+        const port = parseInt(window.location.port, 10);
+        window.location = `http://localhost:${port + 1}/cookie-domain/check.html`;
+      });
+    </script>
+  </body>
+</html>

--- a/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
+++ b/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
@@ -77,6 +77,7 @@ struct BrowserIntegrationTest<'a> {
     grant_permissions: Vec<String>,
     extra_headers: HashMap<String, String>,
     cookies: Vec<(String, String)>,
+    cookie_domain: Option<String>,
 }
 
 impl<'a> BrowserIntegrationTest<'a> {
@@ -90,6 +91,7 @@ impl<'a> BrowserIntegrationTest<'a> {
             grant_permissions: vec![],
             extra_headers: HashMap::new(),
             cookies: vec![],
+            cookie_domain: None,
         }
     }
 
@@ -129,6 +131,11 @@ impl<'a> BrowserIntegrationTest<'a> {
         self
     }
 
+    fn cookie_domain(mut self, domain: impl Into<String>) -> Self {
+        self.cookie_domain = Some(domain.into());
+        self
+    }
+
     /// Run a named browser test with a given expectation.
     ///
     /// Spins up two web servers: one on a random port P, and one on port P + 1, in order to
@@ -149,6 +156,7 @@ impl<'a> BrowserIntegrationTest<'a> {
             grant_permissions,
             extra_headers,
             cookies,
+            cookie_domain,
         } = self;
         setup();
         let _permit = TEST_SEMAPHORE.acquire().await.unwrap();
@@ -260,6 +268,7 @@ impl<'a> BrowserIntegrationTest<'a> {
             grant_permissions,
             extra_headers,
             cookies,
+            cookie_domain,
         };
         let debugger_options = DebuggerOptions::Managed {
             launch_options: LaunchOptions {
@@ -515,6 +524,7 @@ async fn test_browser_lifecycle() {
             grant_permissions: vec![],
             extra_headers: Default::default(),
             cookies: vec![],
+            cookie_domain: None,
         },
         DebuggerOptions::Managed {
             launch_options: LaunchOptions {
@@ -977,6 +987,32 @@ export const sessionCookiePresent = eventually(
   () => cookieSet.current === true
 ).within(10, "seconds");
 "#,
+        )
+        .run()
+        .await;
+}
+
+#[tokio::test]
+async fn test_cookie_domain() {
+    BrowserIntegrationTest::new("cookie-domain")
+        .cookies(vec![("session".to_string(), "bombadil".to_string())])
+        .cookie_domain("localhost")
+        .time_limit(Duration::from_secs(15))
+        .specification(
+            r##"
+import { eventually } from "@antithesishq/bombadil";
+import { extract } from "@antithesishq/bombadil/browser";
+export { clicks } from "@antithesishq/bombadil/browser/defaults/actions";
+
+const cookieOk = extract((state) => {
+  const el = state.document.querySelector("#cookie-ok");
+  return el != null && (el as HTMLElement).offsetParent !== null;
+});
+
+export const sessionCookieOnOtherPort = eventually(
+  () => cookieOk.current === true
+).within(10, "seconds");
+"##,
         )
         .run()
         .await;

--- a/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
+++ b/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
@@ -27,6 +27,7 @@ use bombadil_browser::{
         actions::BrowserAction,
     },
     convert::ToSchema,
+    cookie::BrowserCookie,
     runner,
     strategy::{TestStrategy, TraceWriter},
 };
@@ -76,8 +77,7 @@ struct BrowserIntegrationTest<'a> {
     specification: Option<&'a str>,
     grant_permissions: Vec<String>,
     extra_headers: HashMap<String, String>,
-    cookies: Vec<(String, String)>,
-    cookie_domain: Option<String>,
+    cookies: Vec<BrowserCookie>,
 }
 
 impl<'a> BrowserIntegrationTest<'a> {
@@ -91,7 +91,6 @@ impl<'a> BrowserIntegrationTest<'a> {
             grant_permissions: vec![],
             extra_headers: HashMap::new(),
             cookies: vec![],
-            cookie_domain: None,
         }
     }
 
@@ -126,13 +125,8 @@ impl<'a> BrowserIntegrationTest<'a> {
         self
     }
 
-    fn cookies(mut self, cookies: Vec<(String, String)>) -> Self {
+    fn cookies(mut self, cookies: Vec<BrowserCookie>) -> Self {
         self.cookies = cookies;
-        self
-    }
-
-    fn cookie_domain(mut self, domain: impl Into<String>) -> Self {
-        self.cookie_domain = Some(domain.into());
         self
     }
 
@@ -156,7 +150,6 @@ impl<'a> BrowserIntegrationTest<'a> {
             grant_permissions,
             extra_headers,
             cookies,
-            cookie_domain,
         } = self;
         setup();
         let _permit = TEST_SEMAPHORE.acquire().await.unwrap();
@@ -268,7 +261,6 @@ impl<'a> BrowserIntegrationTest<'a> {
             grant_permissions,
             extra_headers,
             cookies,
-            cookie_domain,
         };
         let debugger_options = DebuggerOptions::Managed {
             launch_options: LaunchOptions {
@@ -524,7 +516,6 @@ async fn test_browser_lifecycle() {
             grant_permissions: vec![],
             extra_headers: Default::default(),
             cookies: vec![],
-            cookie_domain: None,
         },
         DebuggerOptions::Managed {
             launch_options: LaunchOptions {
@@ -971,7 +962,7 @@ export const secretResourceLoaded = eventually(
 #[tokio::test]
 async fn test_cookies() {
     BrowserIntegrationTest::new("fetch-headers")
-        .cookies(vec![("session".to_string(), "bombadil".to_string())])
+        .cookies(vec![BrowserCookie::parse("session=bombadil").unwrap()])
         .time_limit(Duration::from_secs(15))
         .specification(
             r#"
@@ -995,8 +986,9 @@ export const sessionCookiePresent = eventually(
 #[tokio::test]
 async fn test_cookie_domain() {
     BrowserIntegrationTest::new("cookie-domain")
-        .cookies(vec![("session".to_string(), "bombadil".to_string())])
-        .cookie_domain("localhost")
+        .cookies(vec![
+            BrowserCookie::parse("session=bombadil; Domain=localhost").unwrap(),
+        ])
         .time_limit(Duration::from_secs(15))
         .specification(
             r##"

--- a/lib/bombadil-browser/src/browser.rs
+++ b/lib/bombadil-browser/src/browser.rs
@@ -186,6 +186,29 @@ pub struct BrowserOptions {
     pub grant_permissions: Vec<String>,
     pub extra_headers: HashMap<String, String>,
     pub cookies: Vec<(String, String)>,
+    /// When set, cookies are scoped to this domain (e.g. `.example.com`) instead
+    /// of the origin host only. Useful when the test navigates across subdomains.
+    pub cookie_domain: Option<String>,
+}
+
+fn build_cookie_param(
+    name: &str,
+    value: &str,
+    origin: &Url,
+    cookie_domain: Option<&str>,
+) -> Result<network::CookieParam> {
+    let mut builder = network::CookieParam::builder().name(name).value(value);
+    if let Some(domain) = cookie_domain {
+        builder = builder
+            .domain(domain)
+            .path("/")
+            .secure(origin.scheme() == "https");
+    } else {
+        builder = builder.url(origin.as_str());
+    }
+    builder
+        .build()
+        .map_err(|s| anyhow!(s).context("build CookieParam failed"))
 }
 
 #[derive(Clone)]
@@ -275,23 +298,21 @@ impl Browser {
         }
 
         if !browser_options.cookies.is_empty() {
-            // Cookies are associated with the origin URL so that the
-            // browser derives an appropriate domain, path, and scheme.
-            // Unlike a static Cookie request header, these become real
-            // browser cookies and are sent on every navigation, which is
-            // what client-side auth flows (e.g. MSAL) rely on.
+            // Unlike a static Cookie request header, these become real browser
+            // cookies and are sent on every navigation, which is what client-side
+            // auth flows (e.g. MSAL) rely on. By default cookies are associated
+            // with the origin URL; --cookie-domain overrides the domain so cookies
+            // are shared across subdomains (e.g. apex + item-sales).
             let cookies = browser_options
                 .cookies
                 .iter()
                 .map(|(name, value)| {
-                    network::CookieParam::builder()
-                        .name(name)
-                        .value(value)
-                        .url(origin.as_str())
-                        .build()
-                        .map_err(|s| {
-                            anyhow!(s).context("build CookieParam failed")
-                        })
+                    build_cookie_param(
+                        name,
+                        value,
+                        &origin,
+                        browser_options.cookie_domain.as_deref(),
+                    )
                 })
                 .collect::<Result<Vec<_>>>()?;
             page.execute(network::SetCookiesParams::new(cookies))

--- a/lib/bombadil-browser/src/browser.rs
+++ b/lib/bombadil-browser/src/browser.rs
@@ -32,6 +32,7 @@ use crate::browser::state::{
     BrowserState, CallFrame, ConsoleEntry, Exception, Screenshot,
     ScreenshotFormat,
 };
+use crate::cookie::{BrowserCookie, build_cookie_param};
 
 pub mod actions;
 pub mod activity;
@@ -185,30 +186,7 @@ pub struct BrowserOptions {
     pub downloads_directory: PathBuf,
     pub grant_permissions: Vec<String>,
     pub extra_headers: HashMap<String, String>,
-    pub cookies: Vec<(String, String)>,
-    /// When set, cookies are scoped to this domain (e.g. `.example.com`) instead
-    /// of the origin host only. Useful when the test navigates across subdomains.
-    pub cookie_domain: Option<String>,
-}
-
-fn build_cookie_param(
-    name: &str,
-    value: &str,
-    origin: &Url,
-    cookie_domain: Option<&str>,
-) -> Result<network::CookieParam> {
-    let mut builder = network::CookieParam::builder().name(name).value(value);
-    if let Some(domain) = cookie_domain {
-        builder = builder
-            .domain(domain)
-            .path("/")
-            .secure(origin.scheme() == "https");
-    } else {
-        builder = builder.url(origin.as_str());
-    }
-    builder
-        .build()
-        .map_err(|s| anyhow!(s).context("build CookieParam failed"))
+    pub cookies: Vec<BrowserCookie>,
 }
 
 #[derive(Clone)]
@@ -300,20 +278,12 @@ impl Browser {
         if !browser_options.cookies.is_empty() {
             // Unlike a static Cookie request header, these become real browser
             // cookies and are sent on every navigation, which is what client-side
-            // auth flows (e.g. MSAL) rely on. By default cookies are associated
-            // with the origin URL; --cookie-domain overrides the domain so cookies
-            // are shared across subdomains (e.g. apex + item-sales).
+            // auth flows (e.g. MSAL) rely on. Plain NAME=VALUE scopes to the
+            // origin URL; Set-Cookie attributes (Domain, Path, etc.) override that.
             let cookies = browser_options
                 .cookies
                 .iter()
-                .map(|(name, value)| {
-                    build_cookie_param(
-                        name,
-                        value,
-                        &origin,
-                        browser_options.cookie_domain.as_deref(),
-                    )
-                })
+                .map(|cookie| build_cookie_param(cookie, &origin))
                 .collect::<Result<Vec<_>>>()?;
             page.execute(network::SetCookiesParams::new(cookies))
                 .await?;

--- a/lib/bombadil-browser/src/cookie.rs
+++ b/lib/bombadil-browser/src/cookie.rs
@@ -1,0 +1,175 @@
+use anyhow::{Result, anyhow};
+use chromiumoxide::cdp::browser_protocol::network;
+use url::Url;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BrowserCookie {
+    raw: String,
+    pub name: String,
+    pub value: String,
+    pub domain: Option<String>,
+    pub path: Option<String>,
+    pub secure: bool,
+    pub http_only: bool,
+}
+
+impl BrowserCookie {
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Err("cookie must not be empty".into());
+        }
+
+        let mut segments = raw.split(';').map(str::trim);
+        let name_value = segments
+            .next()
+            .ok_or_else(|| "cookie must start with NAME=VALUE".to_string())?;
+        let (name, value) = name_value.split_once('=').ok_or_else(|| {
+            format!("invalid cookie {name_value:?}, expected NAME=VALUE")
+        })?;
+        if name.is_empty() {
+            return Err("cookie name must not be empty".into());
+        }
+
+        let mut cookie = BrowserCookie {
+            raw: raw.to_string(),
+            name: name.to_string(),
+            value: unquote(value),
+            domain: None,
+            path: None,
+            secure: false,
+            http_only: false,
+        };
+
+        for segment in segments {
+            if segment.is_empty() {
+                continue;
+            }
+            if let Some((attribute, attribute_value)) = segment.split_once('=')
+            {
+                match attribute.trim().to_ascii_lowercase().as_str() {
+                    "domain" => {
+                        cookie.domain = Some(unquote(attribute_value.trim()));
+                    }
+                    "path" => {
+                        cookie.path = Some(unquote(attribute_value.trim()));
+                    }
+                    other => {
+                        return Err(format!(
+                            "unknown cookie attribute {other:?}"
+                        ));
+                    }
+                }
+            } else {
+                match segment.to_ascii_lowercase().as_str() {
+                    "secure" => cookie.secure = true,
+                    "httponly" => cookie.http_only = true,
+                    other => {
+                        return Err(format!(
+                            "unknown cookie attribute {other:?}"
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(cookie)
+    }
+
+    pub fn cli_value(&self) -> &str {
+        &self.raw
+    }
+}
+
+pub fn build_cookie_param(
+    cookie: &BrowserCookie,
+    origin: &Url,
+) -> Result<network::CookieParam> {
+    let mut builder = network::CookieParam::builder()
+        .name(&cookie.name)
+        .value(&cookie.value);
+
+    if cookie.domain.is_some() || cookie.path.is_some() {
+        let domain = cookie
+            .domain
+            .as_deref()
+            .or_else(|| origin.host_str())
+            .ok_or_else(|| anyhow!("origin URL has no host"))?;
+        builder = builder
+            .domain(domain)
+            .path(cookie.path.as_deref().unwrap_or("/"))
+            .secure(cookie.secure || origin.scheme() == "https");
+        if cookie.http_only {
+            builder = builder.http_only(true);
+        }
+    } else {
+        builder = builder.url(origin.as_str());
+        if cookie.secure {
+            builder = builder.secure(true);
+        }
+        if cookie.http_only {
+            builder = builder.http_only(true);
+        }
+    }
+
+    builder
+        .build()
+        .map_err(|s| anyhow!("build CookieParam failed: {s}"))
+}
+
+fn unquote(value: &str) -> String {
+    if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
+        value[1..value.len() - 1].to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_name_value_only() {
+        let cookie = BrowserCookie::parse("session=abc").unwrap();
+        assert_eq!(cookie.name, "session");
+        assert_eq!(cookie.value, "abc");
+        assert_eq!(cookie.domain, None);
+        assert_eq!(cookie.path, None);
+        assert!(!cookie.secure);
+        assert!(!cookie.http_only);
+    }
+
+    #[test]
+    fn parse_value_with_equals_sign() {
+        let cookie = BrowserCookie::parse("token=a=b=c").unwrap();
+        assert_eq!(cookie.name, "token");
+        assert_eq!(cookie.value, "a=b=c");
+    }
+
+    #[test]
+    fn parse_set_cookie_attributes() {
+        let cookie = BrowserCookie::parse(
+            "session=abc; Domain=.example.com; Path=/app; Secure; HttpOnly",
+        )
+        .unwrap();
+        assert_eq!(cookie.name, "session");
+        assert_eq!(cookie.value, "abc");
+        assert_eq!(cookie.domain.as_deref(), Some(".example.com"));
+        assert_eq!(cookie.path.as_deref(), Some("/app"));
+        assert!(cookie.secure);
+        assert!(cookie.http_only);
+    }
+
+    #[test]
+    fn parse_domain_is_case_insensitive() {
+        let cookie =
+            BrowserCookie::parse("session=abc; domain=localhost").unwrap();
+        assert_eq!(cookie.domain.as_deref(), Some("localhost"));
+    }
+
+    #[test]
+    fn rejects_unknown_attribute() {
+        assert!(BrowserCookie::parse("session=abc; Expires=Wed").is_err());
+    }
+}

--- a/lib/bombadil-browser/src/lib.rs
+++ b/lib/bombadil-browser/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod browser;
 pub mod convert;
+pub mod cookie;
 pub mod driver;
 pub mod geometry;
 pub mod instrumentation;

--- a/lib/bombadil-cli/src/browser.rs
+++ b/lib/bombadil-cli/src/browser.rs
@@ -121,11 +121,15 @@ pub struct TestSharedOptions {
     #[arg(long = "header", value_name = "KEY=VALUE", value_parser = parse_header)]
     pub headers: Vec<(String, String)>,
     /// Cookie to set in the browser before testing, in NAME=VALUE format.
-    /// Set as a real browser cookie scoped to the origin (so client-side auth
-    /// flows that read cookies work), unlike --header which only sends a
-    /// static request header. Can be specified multiple times.
+    /// By default cookies are scoped to the origin host. Use with
+    /// `--cookie-domain` to share cookies across subdomains. Unlike `--header`,
+    /// these become real browser cookies. Can be specified multiple times.
     #[arg(long = "cookie", value_name = "NAME=VALUE", value_parser = parse_header)]
     pub cookies: Vec<(String, String)>,
+    /// Domain to scope `--cookie` values to (e.g. `.example.com`), so cookies
+    /// are sent on subdomains as well as the origin host.
+    #[arg(long)]
+    pub cookie_domain: Option<String>,
     /// Reproduce a previous test run from a trace file, instead of random exploration.
     /// Mutually exclusive with --time-limit and --exit-on-violation.
     #[arg(long, value_name = "TRACE_FILE", conflicts_with_all = ["time_limit", "exit_on_violation"])]
@@ -293,6 +297,7 @@ fn browser_options_from_shared(
             .collect(),
         extra_headers: shared.headers.iter().cloned().collect(),
         cookies: shared.cookies.clone(),
+        cookie_domain: shared.cookie_domain.clone(),
     }
 }
 
@@ -323,6 +328,9 @@ fn reproduce_command_args(
     }
     for (name, value) in &shared.cookies {
         args.push(format!("--cookie {name}={value}"));
+    }
+    if let Some(domain) = &shared.cookie_domain {
+        args.push(format!("--cookie-domain {domain}"));
     }
     args
 }

--- a/lib/bombadil-cli/src/browser.rs
+++ b/lib/bombadil-cli/src/browser.rs
@@ -2,7 +2,8 @@ use ::url::Url;
 use antithesis_sdk::random::AntithesisRng;
 use anyhow::Result;
 use bombadil_browser::{
-    browser::LaunchOptions, convert::ToInternal, trace::writer::FileTraceWriter,
+    browser::LaunchOptions, convert::ToInternal, cookie::BrowserCookie,
+    trace::writer::FileTraceWriter,
 };
 use clap::Args;
 use serde_json as json;
@@ -120,16 +121,12 @@ pub struct TestSharedOptions {
     /// Can be specified multiple times.
     #[arg(long = "header", value_name = "KEY=VALUE", value_parser = parse_header)]
     pub headers: Vec<(String, String)>,
-    /// Cookie to set in the browser before testing, in NAME=VALUE format.
-    /// By default cookies are scoped to the origin host. Use with
-    /// `--cookie-domain` to share cookies across subdomains. Unlike `--header`,
-    /// these become real browser cookies. Can be specified multiple times.
-    #[arg(long = "cookie", value_name = "NAME=VALUE", value_parser = parse_header)]
-    pub cookies: Vec<(String, String)>,
-    /// Domain to scope `--cookie` values to (e.g. `.example.com`), so cookies
-    /// are sent on subdomains as well as the origin host.
-    #[arg(long)]
-    pub cookie_domain: Option<String>,
+    /// Cookie to set in the browser before testing. Accepts plain NAME=VALUE
+    /// (scoped to the origin) or Set-Cookie syntax with attributes such as
+    /// Domain, Path, Secure, and HttpOnly. Unlike `--header`, these become real
+    /// browser cookies. Can be specified multiple times.
+    #[arg(long = "cookie", value_name = "SET-COOKIE", value_parser = parse_cookie)]
+    pub cookies: Vec<BrowserCookie>,
     /// Reproduce a previous test run from a trace file, instead of random exploration.
     /// Mutually exclusive with --time-limit and --exit-on-violation.
     #[arg(long, value_name = "TRACE_FILE", conflicts_with_all = ["time_limit", "exit_on_violation"])]
@@ -245,6 +242,10 @@ fn parse_header(s: &str) -> std::result::Result<(String, String), String> {
         .ok_or_else(|| format!("invalid header {:?}, expected KEY=VALUE", s))
 }
 
+fn parse_cookie(s: &str) -> std::result::Result<BrowserCookie, String> {
+    BrowserCookie::parse(s)
+}
+
 fn parse_instrumentation_config(
     s: &str,
 ) -> std::result::Result<InstrumentationConfig, String> {
@@ -297,7 +298,6 @@ fn browser_options_from_shared(
             .collect(),
         extra_headers: shared.headers.iter().cloned().collect(),
         cookies: shared.cookies.clone(),
-        cookie_domain: shared.cookie_domain.clone(),
     }
 }
 
@@ -326,11 +326,8 @@ fn reproduce_command_args(
     for (key, value) in &shared.headers {
         args.push(format!("--header {key}={value}"));
     }
-    for (name, value) in &shared.cookies {
-        args.push(format!("--cookie {name}={value}"));
-    }
-    if let Some(domain) = &shared.cookie_domain {
-        args.push(format!("--cookie-domain {domain}"));
+    for cookie in &shared.cookies {
+        args.push(format!("--cookie {}", cookie.cli_value()));
     }
     args
 }


### PR DESCRIPTION
## Summary

Follow-up to #232: extend `--cookie` to accept Set-Cookie syntax so per-cookie attributes can be set inline.

Without a `Domain` attribute, a cookie set for one host (e.g. `app.example.com`) is not sent on sibling subdomains (e.g. `api.example.com`). Adding `Domain` to the `--cookie` value mirrors the common pattern of setting a site-wide auth cookie on the registrable domain.

## Usage

```bash
bombadil browser test https://app.example.com app.spec.ts \
  --cookie "session=$TOKEN"

bombadil browser test https://app.example.com app.spec.ts \
  --cookie "session=$TOKEN; Domain=.example.com"
```

Plain `NAME=VALUE` still scopes to the origin host via CDP `url=<origin>`.

Supported attributes: `Domain`, `Path`, `Secure`, `HttpOnly`.

## Implementation

- `BrowserCookie::parse()` in `bombadil-browser`
- CDP `CookieParam` built from parsed name, value, and attributes
- Integration test: cookie with `Domain` visible after navigation to another port
- Reproduce command forwards `--cookie` values unchanged
- Manual reference docs updated

## Test plan

- [x] `cargo test -p bombadil-browser cookie::`
- [x] `cargo test -p bombadil-browser-integration-tests test_cookie`
- [x] `nix build .#checks.aarch64-darwin.fmt`