### PR TITLE
Add --allow-url option for browser exploration boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # The Bombadil Changelog
 
-## Unreleased
-
-Major updates:
-
-* Add `--allow-url` to widen the exploration boundary beyond the origin host, accepting domains (with subdomains) or URL path prefixes
-
 ## 0.6.1
 
 Major updates:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Major updates:
 
+* Add `--allow-url` to widen the exploration boundary beyond the origin host, accepting domains (with subdomains) or URL path prefixes
 * Add `--cookie NAME=VALUE` option to set real browser cookies before testing, scoped to the origin (useful for client-side auth flows that read cookies, unlike `--header`)
 
 ## 0.6.1

--- a/docs/manual/src/04-reference.md
+++ b/docs/manual/src/04-reference.md
@@ -21,7 +21,7 @@
 ::: {#arguments-test}
 | Argument | Description |
 |----------|-------------|
-| `<ORIGIN>` | Starting URL of the test (also used as a boundary so that Bombadil doesn't navigate to other websites) |
+| `<ORIGIN>` | Starting URL of the test (also used as a boundary so that Bombadil doesn't navigate to other websites). The origin host is always allowed; use `--allow-url` to widen the boundary |
 | `[SPECIFICATION_FILE]` | A custom specification in TypeScript or JavaScript, using the `@antithesishq/bombadil` package on NPM |
 :::
 
@@ -39,6 +39,7 @@
 | `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--header <KEY=VALUE>` | Extra HTTP header to send with all browser requests, in `KEY=VALUE format`. Can be specified multiple times. | |
 | `--cookie <NAME=VALUE>` | Cookie to set in the browser before testing, in `NAME=VALUE` format. Set as a real browser cookie scoped to the origin, unlike `--header` which only sends a static request header. Can be specified multiple times. | |
+| `--allow-url <URL_OR_DOMAIN>` | Additional URL or domain where exploration is allowed. Domains allow that host and its subdomains; URLs allow prefix-matched paths on that host. Can be specified multiple times. | |
 | `--reproduce <TRACE_FILE>` | Reproduce a previous test run from a trace file, instead of random exploration. Mutually exclusive with `--time-limit` and `--exit-on-violation`. | |
 | `--headless` | Whether the browser should run in a visible window or not | |
 | `--no-sandbox` | Disable Chromium sandboxing | |
@@ -52,7 +53,7 @@
 ::: {#arguments-test-external}
 | Argument | Description |
 |----------|-------------|
-| `<ORIGIN>` | Starting URL of the test (also used as a boundary so that Bombadil doesn't navigate to other websites) |
+| `<ORIGIN>` | Starting URL of the test (also used as a boundary so that Bombadil doesn't navigate to other websites). The origin host is always allowed; use `--allow-url` to widen the boundary |
 | `[SPECIFICATION_FILE]` | A custom specification in TypeScript or JavaScript, using the `@antithesishq/bombadil` package on NPM |
 :::
 
@@ -70,6 +71,7 @@
 | `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--header <KEY=VALUE>` | Extra HTTP header to send with all browser requests, in `KEY=VALUE format`. Can be specified multiple times. | |
 | `--cookie <NAME=VALUE>` | Cookie to set in the browser before testing, in `NAME=VALUE` format. Set as a real browser cookie scoped to the origin, unlike `--header` which only sends a static request header. Can be specified multiple times. | |
+| `--allow-url <URL_OR_DOMAIN>` | Additional URL or domain where exploration is allowed. Domains allow that host and its subdomains; URLs allow prefix-matched paths on that host. Can be specified multiple times. | |
 | `--reproduce <TRACE_FILE>` | Reproduce a previous test run from a trace file, instead of random exploration. Mutually exclusive with `--time-limit` and `--exit-on-violation`. | |
 | `--remote-debugger <REMOTE_DEBUGGER>` | Address to the remote debugger's server, e.g. http://localhost:9222 | |
 | `--create-target` | Whether Bombadil should create a new tab and navigate to the origin URL in it, as part of starting the test (this should probably be false if you test an Electron app) | |

--- a/docs/manual/src/04-reference.md
+++ b/docs/manual/src/04-reference.md
@@ -21,7 +21,7 @@
 ::: {#arguments-test}
 | Argument | Description |
 |----------|-------------|
-| `<ORIGIN>` | Starting URL of the test (also used as a boundary so that Bombadil doesn't navigate to other websites). The origin host is always allowed; use `--allow-url` to widen the boundary |
+| `<ORIGIN>` | Starting URL of the test. Without `--allow-url`, exploration stays on this origin host. With `--allow-url`, those entries define the boundary instead (include the origin if needed) |
 | `[SPECIFICATION_FILE]` | A custom specification in TypeScript or JavaScript, using the `@antithesishq/bombadil` package on NPM |
 :::
 
@@ -39,7 +39,7 @@
 | `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--header <KEY=VALUE>` | Extra HTTP header to send with all browser requests, in `KEY=VALUE format`. Can be specified multiple times. | |
 | `--cookie <SET-COOKIE>` | Cookie to set in the browser before testing. Plain `NAME=VALUE` scopes to the origin; Set-Cookie attributes (`Domain`, `Path`, `Secure`, `HttpOnly`) are supported. Unlike `--header`, these become real browser cookies. Can be specified multiple times. | |
-| `--allow-url <URL_OR_DOMAIN>` | Additional URL or domain where exploration is allowed. Domains allow that host and its subdomains; URLs allow prefix-matched paths on that host. Can be specified multiple times. | |
+| `--allow-url <URL_OR_DOMAIN>` | Exploration boundary when set (replaces the default origin-only rule). Domains allow that host and its subdomains; http(s) URLs allow prefix-matched paths; `file://` paths match exactly. Can be specified multiple times. | |
 | `--reproduce <TRACE_FILE>` | Reproduce a previous test run from a trace file, instead of random exploration. Mutually exclusive with `--time-limit` and `--exit-on-violation`. | |
 | `--headless` | Whether the browser should run in a visible window or not | |
 | `--no-sandbox` | Disable Chromium sandboxing | |
@@ -53,7 +53,7 @@
 ::: {#arguments-test-external}
 | Argument | Description |
 |----------|-------------|
-| `<ORIGIN>` | Starting URL of the test (also used as a boundary so that Bombadil doesn't navigate to other websites). The origin host is always allowed; use `--allow-url` to widen the boundary |
+| `<ORIGIN>` | Starting URL of the test. Without `--allow-url`, exploration stays on this origin host. With `--allow-url`, those entries define the boundary instead (include the origin if needed) |
 | `[SPECIFICATION_FILE]` | A custom specification in TypeScript or JavaScript, using the `@antithesishq/bombadil` package on NPM |
 :::
 
@@ -71,7 +71,7 @@
 | `--chrome-grant-permissions <CHROME_GRANT_PERMISSIONS>` | Comma-separated list of Chrome permissions to grant. Examples: local-network-access, geolocation, notifications. | local-network-access,local-network,loopback-network |
 | `--header <KEY=VALUE>` | Extra HTTP header to send with all browser requests, in `KEY=VALUE format`. Can be specified multiple times. | |
 | `--cookie <SET-COOKIE>` | Cookie to set in the browser before testing. Plain `NAME=VALUE` scopes to the origin; Set-Cookie attributes (`Domain`, `Path`, `Secure`, `HttpOnly`) are supported. Unlike `--header`, these become real browser cookies. Can be specified multiple times. | |
-| `--allow-url <URL_OR_DOMAIN>` | Additional URL or domain where exploration is allowed. Domains allow that host and its subdomains; URLs allow prefix-matched paths on that host. Can be specified multiple times. | |
+| `--allow-url <URL_OR_DOMAIN>` | Exploration boundary when set (replaces the default origin-only rule). Domains allow that host and its subdomains; http(s) URLs allow prefix-matched paths; `file://` paths match exactly. Can be specified multiple times. | |
 | `--reproduce <TRACE_FILE>` | Reproduce a previous test run from a trace file, instead of random exploration. Mutually exclusive with `--time-limit` and `--exit-on-violation`. | |
 | `--remote-debugger <REMOTE_DEBUGGER>` | Address to the remote debugger's server, e.g. http://localhost:9222 | |
 | `--create-target` | Whether Bombadil should create a new tab and navigate to the origin URL in it, as part of starting the test (this should probably be false if you test an Electron app) | |

--- a/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
+++ b/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
@@ -77,6 +77,7 @@ struct BrowserIntegrationTest<'a> {
     grant_permissions: Vec<String>,
     extra_headers: HashMap<String, String>,
     cookies: Vec<(String, String)>,
+    allow_urls: Vec<bombadil_browser::allow_url::AllowUrl>,
 }
 
 impl<'a> BrowserIntegrationTest<'a> {
@@ -90,6 +91,7 @@ impl<'a> BrowserIntegrationTest<'a> {
             grant_permissions: vec![],
             extra_headers: HashMap::new(),
             cookies: vec![],
+            allow_urls: vec![],
         }
     }
 
@@ -129,6 +131,14 @@ impl<'a> BrowserIntegrationTest<'a> {
         self
     }
 
+    fn allow_urls(
+        mut self,
+        allow_urls: Vec<bombadil_browser::allow_url::AllowUrl>,
+    ) -> Self {
+        self.allow_urls = allow_urls;
+        self
+    }
+
     /// Run a named browser test with a given expectation.
     ///
     /// Spins up two web servers: one on a random port P, and one on port P + 1, in order to
@@ -149,6 +159,7 @@ impl<'a> BrowserIntegrationTest<'a> {
             grant_permissions,
             extra_headers,
             cookies,
+            allow_urls,
         } = self;
         setup();
         let _permit = TEST_SEMAPHORE.acquire().await.unwrap();
@@ -322,6 +333,10 @@ impl<'a> BrowserIntegrationTest<'a> {
             )
             .expect("run_test failed");
 
+            let allow_urls = bombadil_browser::allow_url::build_allow_list(
+                &origin,
+                &allow_urls,
+            );
             let mut strategy = TestStrategy {
                 rng: rand::prelude::StdRng::seed_from_u64(seed),
                 test_start: Some(Time::from_system_time(test_start)),
@@ -330,6 +345,7 @@ impl<'a> BrowserIntegrationTest<'a> {
                 writer,
                 exit_on_violation: true,
                 origin,
+                allow_urls,
                 output_path: output_path_buf,
                 violations_count: 0,
             };
@@ -954,6 +970,77 @@ export const secretResourceLoaded = eventually(
 ).within(10, "seconds");
 "#,
         )
+        .run()
+        .await;
+}
+
+const SUBDOMAIN_ALLOW_URL_SPEC: &str = r##"
+import { eventually } from "@antithesishq/bombadil";
+import { actions, extract } from "@antithesishq/bombadil/browser";
+import { clicks } from "@antithesishq/bombadil/browser/defaults/actions";
+
+const onSubdomain = extract(
+  (state) => state.window.location.hostname === "app.localhost"
+);
+
+const subdomainActions = actions(() => {
+  if (onSubdomain.current) {
+    return ["Wait"];
+  }
+  return clicks.generate();
+});
+
+const subdomainOk = extract((state) => {
+  const el = state.document.querySelector("#subdomain-ok");
+  return el != null && (el as HTMLElement).offsetParent !== null;
+});
+
+export { subdomainActions as clicks };
+
+export const exploredSubdomain = eventually(
+  () => subdomainOk.current === true
+).within(10, "seconds");
+"##;
+
+const SUBDOMAIN_ALLOW_URL_WAIT_ONLY_SPEC: &str = r##"
+import { always } from "@antithesishq/bombadil";
+import { actions, extract } from "@antithesishq/bombadil/browser";
+import { clicks } from "@antithesishq/bombadil/browser/defaults/actions";
+
+const onSubdomain = extract(
+  (state) => state.window.location.hostname === "app.localhost"
+);
+
+const subdomainActions = actions(() => {
+  if (onSubdomain.current) {
+    return ["Wait"];
+  }
+  return clicks.generate();
+});
+
+export { subdomainActions as clicks };
+
+export const keepRunning = always(() => true);
+"##;
+
+#[tokio::test]
+async fn test_allow_url_subdomain() {
+    BrowserIntegrationTest::new("subdomain-origin")
+        .allow_urls(vec![
+            bombadil_browser::allow_url::AllowUrl::parse("localhost").unwrap(),
+        ])
+        .time_limit(Duration::from_secs(15))
+        .specification(SUBDOMAIN_ALLOW_URL_SPEC)
+        .run()
+        .await;
+}
+
+#[tokio::test]
+async fn test_allow_url_required_for_subdomain_wait() {
+    BrowserIntegrationTest::new("subdomain-origin")
+        .expect_error("no actions available")
+        .time_limit(Duration::from_secs(15))
+        .specification(SUBDOMAIN_ALLOW_URL_WAIT_ONLY_SPEC)
         .run()
         .await;
 }

--- a/lib/bombadil-browser-integration-tests/tests/subdomain-origin/index.html
+++ b/lib/bombadil-browser-integration-tests/tests/subdomain-origin/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Subdomain origin</title>
+    <style>
+      button {
+        display: block;
+        padding: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <button id="go">Go to subdomain</button>
+    <script>
+      document.getElementById("go").addEventListener("click", () => {
+        const port = window.location.port;
+        window.location = `http://app.localhost:${port}/subdomain-origin/inner.html`;
+      });
+    </script>
+  </body>
+</html>

--- a/lib/bombadil-browser-integration-tests/tests/subdomain-origin/inner.html
+++ b/lib/bombadil-browser-integration-tests/tests/subdomain-origin/inner.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Subdomain inner</title>
+  </head>
+  <body>
+    <div id="subdomain-ok">ok</div>
+  </body>
+</html>

--- a/lib/bombadil-browser/src/allow_url.rs
+++ b/lib/bombadil-browser/src/allow_url.rs
@@ -48,10 +48,9 @@ impl AllowUrl {
     /// Implicit allow rule for the test origin, if it has a network host.
     ///
     /// Origins without a host (e.g. `file://`) produce no rule. Host-less
-    /// *targets* such as `about:blank` and other `file://` pages are handled
-    /// separately in [`is_url_allowed`], so exploration still works for
-    /// inspect reports and mid-navigation blanks without a dedicated allow-url
-    /// variant.
+    /// *targets* (other than `about:` URLs) are handled in [`is_url_allowed`]:
+    /// allowed only when the origin is also host-less (inspect/`file://`).
+    /// Any `about:` URL is always out of bounds.
     pub fn from_origin(origin: &Url) -> Option<Self> {
         origin.host_str().map(|host| AllowUrl::ExactHost {
             host: host.to_string(),
@@ -131,11 +130,16 @@ pub fn is_url_allowed(
     allow_urls: &[AllowUrl],
     origin: &Url,
 ) -> bool {
-    // Host-less targets (about:blank mid-navigation, file:// pages, etc.) are
-    // always in-bounds so we do not hit "no actions available" between
-    // navigations. Separate from the allow-list rules (network hosts only).
+    // about: URLs (blank, srcdoc, …) are tab setup or non-app chrome, never
+    // exploration targets; out of bounds → Back only.
+    if uri.scheme() == "about" {
+        return false;
+    }
+    // Other host-less URLs (typical file:// pages) have no network host to
+    // match against the allow-list. Allow them only when the test origin is
+    // also host-less (e.g. file:// inspect reports).
     if uri.host().is_none() {
-        return true;
+        return origin.host().is_none();
     }
     allow_urls.iter().any(|rule| rule.matches(uri, origin))
 }
@@ -226,19 +230,18 @@ mod tests {
     }
 
     #[test]
-    fn file_origin_has_no_implicit_rule_but_allows_hostless_targets() {
+    fn file_origin_allows_other_file_urls_but_not_about_blank() {
         let origin = url("file:///tmp/index.html");
         let rules = build_allow_list(&origin, &[]);
         assert!(rules.is_empty());
         assert!(AllowUrl::from_origin(&origin).is_none());
-        // Other file:// pages and about:blank stay in-bounds via the host-less
-        // target special case, not via an allow-list rule.
         assert!(is_url_allowed(
             &url("file:///tmp/other.html"),
             &rules,
             &origin
         ));
-        assert!(is_url_allowed(&url("about:blank"), &rules, &origin));
+        // about: URLs are never exploration targets.
+        assert!(!is_url_allowed(&url("about:blank"), &rules, &origin));
         assert!(!is_url_allowed(
             &url("https://example.com/"),
             &rules,
@@ -247,10 +250,35 @@ mod tests {
     }
 
     #[test]
-    fn hostless_urls_are_allowed() {
+    fn about_scheme_is_always_out_of_bounds() {
+        let network = url("http://localhost:1073/");
+        let network_rules = allow("http://localhost:1073/", &[]);
+        assert!(!is_url_allowed(
+            &url("about:blank"),
+            &network_rules,
+            &network
+        ));
+        assert!(!is_url_allowed(
+            &url("about:srcdoc"),
+            &network_rules,
+            &network
+        ));
+
+        let file = url("file:///tmp/index.html");
+        let file_rules = build_allow_list(&file, &[]);
+        assert!(!is_url_allowed(&url("about:blank"), &file_rules, &file));
+        assert!(!is_url_allowed(&url("about:srcdoc"), &file_rules, &file));
+    }
+
+    #[test]
+    fn network_origin_rejects_file_urls() {
         let origin = url("http://localhost:1073/");
         let rules = allow("http://localhost:1073/", &[]);
-        assert!(is_url_allowed(&url("about:blank"), &rules, &origin));
+        assert!(!is_url_allowed(
+            &url("file:///tmp/other.html"),
+            &rules,
+            &origin
+        ));
     }
 
     #[test]

--- a/lib/bombadil-browser/src/allow_url.rs
+++ b/lib/bombadil-browser/src/allow_url.rs
@@ -331,27 +331,20 @@ mod tests {
         assert_eq!(parsed, allow);
     }
 
-    /// An allow-url built from a URL's fields allows that URL.
-    /// Origin is the same URL so Domain's port check against origin does not fail.
+    /// Given Url `u` that parses as AllowUrl `a`, `is_url_allowed(u, &[a], origin)`.
+    /// Origin is `u` so Domain's port check against origin does not fail.
     #[hegel::test]
-    fn allow_url_allows_matching_url(tc: TestCase) {
-        let seed = draw_network_url(&tc);
-        let host = seed.host_str().unwrap().to_string();
-        let allow = if tc.draw(booleans()) {
-            AllowUrl::Domain {
-                domain: host.clone(),
-            }
+    fn is_url_allowed_when_parsed_from_url(tc: TestCase) {
+        let u = draw_network_url(&tc);
+        // Domain form (host only) or full URL form — both are valid --allow-url inputs.
+        let a = if tc.draw(booleans()) {
+            AllowUrl::parse(u.host_str().unwrap()).unwrap()
         } else {
-            AllowUrl::UrlPrefix {
-                scheme: seed.scheme().to_string(),
-                host,
-                port: seed.port(),
-                path_prefix: normalize_path_prefix(seed.path()),
-            }
+            AllowUrl::parse(u.as_str()).unwrap_or_else(|_| tc.reject())
         };
         assert!(
-            is_url_allowed(&seed, std::slice::from_ref(&allow), &seed),
-            "url {seed} should be allowed by {allow}"
+            is_url_allowed(&u, std::slice::from_ref(&a), &u),
+            "url {u} should be allowed by {a}"
         );
     }
 }

--- a/lib/bombadil-browser/src/allow_url.rs
+++ b/lib/bombadil-browser/src/allow_url.rs
@@ -2,10 +2,9 @@ use url::Url;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AllowUrl {
-    /// The starting origin host. Added implicitly; any path on this host is allowed.
+    /// The starting origin host. Added implicitly when the origin has a host;
+    /// any path on this host is allowed.
     ExactHost { host: String, port: Option<u16> },
-    /// Origin without a network host (e.g. file://).
-    Hostless { port: Option<u16> },
     /// A registrable domain and its subdomains (e.g. `example.com`, `.example.com`).
     Domain { domain: String },
     /// A URL prefix: scheme, host, port, and path prefix must match.
@@ -44,21 +43,23 @@ impl AllowUrl {
         })
     }
 
-    pub fn from_origin(origin: &Url) -> Self {
-        match origin.host_str() {
-            Some(host) => AllowUrl::ExactHost {
-                host: host.to_string(),
-                port: origin.port(),
-            },
-            None => AllowUrl::Hostless {
-                port: origin.port(),
-            },
-        }
+    /// Implicit allow rule for the test origin, if it has a network host.
+    ///
+    /// Origins without a host (e.g. `file://`) produce no rule. Host-less
+    /// *targets* such as `about:blank` and other `file://` pages are handled
+    /// separately in [`is_url_allowed`], so exploration still works for
+    /// inspect reports and mid-navigation blanks without a dedicated allow-url
+    /// variant.
+    pub fn from_origin(origin: &Url) -> Option<Self> {
+        origin.host_str().map(|host| AllowUrl::ExactHost {
+            host: host.to_string(),
+            port: origin.port(),
+        })
     }
 
     pub fn cli_value(&self) -> String {
         match self {
-            AllowUrl::ExactHost { .. } | AllowUrl::Hostless { .. } => {
+            AllowUrl::ExactHost { .. } => {
                 panic!("origin allow-url is implicit and not reproduced")
             }
             AllowUrl::Domain { domain } => domain.clone(),
@@ -87,17 +88,12 @@ impl AllowUrl {
                 uri.host_str() == Some(host.as_str())
                     && ports_match(uri.port(), *port, origin.port())
             }
-            AllowUrl::Hostless { port } => {
-                uri.host().is_none()
-                    && ports_match(uri.port(), *port, origin.port())
-            }
             AllowUrl::Domain { domain } => {
                 if uri.port().is_some() && uri.port() != origin.port() {
                     return false;
                 }
-                let uri_host = match uri.host_str() {
-                    Some(host) => host,
-                    None => return uri.host().is_none(),
+                let Some(uri_host) = uri.host_str() else {
+                    return false;
                 };
                 host_matches_domain(uri_host, domain)
             }
@@ -117,7 +113,10 @@ impl AllowUrl {
 }
 
 pub fn build_allow_list(origin: &Url, extra: &[AllowUrl]) -> Vec<AllowUrl> {
-    let mut allow_urls = vec![AllowUrl::from_origin(origin)];
+    let mut allow_urls = Vec::new();
+    if let Some(origin_rule) = AllowUrl::from_origin(origin) {
+        allow_urls.push(origin_rule);
+    }
     allow_urls.extend(extra.iter().cloned());
     allow_urls
 }
@@ -127,8 +126,9 @@ pub fn is_url_allowed(
     allow_urls: &[AllowUrl],
     origin: &Url,
 ) -> bool {
-    // Preserve the previous origin-boundary behavior for host-less URLs (e.g.
-    // about:blank while a page is loading or reloading).
+    // Host-less targets (about:blank mid-navigation, file:// pages, etc.) are
+    // always treated as in-bounds so the action set does not go empty. This is
+    // separate from the allow-list rules, which only apply to networked hosts.
     if uri.host().is_none() {
         return uri.port().is_none() || uri.port() == origin.port();
     }
@@ -191,15 +191,19 @@ mod tests {
     }
 
     #[test]
-    fn file_origin_allows_hostless_urls() {
+    fn file_origin_has_no_implicit_rule_but_allows_hostless_targets() {
         let origin = url("file:///tmp/index.html");
         let rules = build_allow_list(&origin, &[]);
-        assert!(matches!(rules[0], AllowUrl::Hostless { .. }));
+        assert!(rules.is_empty());
+        assert!(AllowUrl::from_origin(&origin).is_none());
+        // Other file:// pages and about:blank stay in-bounds via the host-less
+        // target special case, not via an allow-list rule.
         assert!(is_url_allowed(
             &url("file:///tmp/other.html"),
             &rules,
             &origin
         ));
+        assert!(is_url_allowed(&url("about:blank"), &rules, &origin));
         assert!(!is_url_allowed(
             &url("https://example.com/"),
             &rules,

--- a/lib/bombadil-browser/src/allow_url.rs
+++ b/lib/bombadil-browser/src/allow_url.rs
@@ -83,9 +83,7 @@ impl AllowUrl {
                 if uri.scheme() != "file" {
                     return false;
                 }
-                absolute_file_path(uri)
-                    .map(|p| p == *path)
-                    .unwrap_or(false)
+                absolute_file_path(uri).map(|p| p == *path).unwrap_or(false)
             }
             AllowUrl::Domain { domain } => {
                 let Some(uri_host) = uri.host_str() else {
@@ -116,7 +114,8 @@ impl Display for AllowUrl {
                 panic!("origin allow-url is implicit and not reproduced")
             }
             AllowUrl::ExactFile { path } => {
-                let url = Url::from_file_path(path).map_err(|_| std::fmt::Error)?;
+                let url =
+                    Url::from_file_path(path).map_err(|_| std::fmt::Error)?;
                 write!(f, "{url}")
             }
             AllowUrl::Domain { domain } => write!(f, "{domain}"),
@@ -169,8 +168,9 @@ fn absolute_file_path(url: &Url) -> Result<PathBuf, String> {
     let path = url
         .to_file_path()
         .map_err(|()| format!("invalid file URL {url}"))?;
-    std::path::absolute(path)
-        .map_err(|err| format!("could not resolve absolute path for {url}: {err}"))
+    std::path::absolute(path).map_err(|err| {
+        format!("could not resolve absolute path for {url}: {err}")
+    })
 }
 
 fn normalize_domain(domain: &str) -> String {
@@ -277,8 +277,8 @@ mod tests {
     fn file_allow_url_is_exact_match() {
         let origin = url("https://example.com/");
         let allowed = url("file:///tmp/allowed.html");
-        let allowed_abs = Url::from_file_path(absolute_file_path(&allowed).unwrap())
-            .unwrap();
+        let allowed_abs =
+            Url::from_file_path(absolute_file_path(&allowed).unwrap()).unwrap();
         let rules = build_allow_list(
             &origin,
             &[AllowUrl::parse(allowed_abs.as_str()).unwrap()],
@@ -335,14 +335,8 @@ mod tests {
     #[test]
     fn domain_entry_allows_subdomains() {
         let rules = allow("https://example.com/", &[".example.com"]);
-        assert!(is_url_allowed(
-            &url("https://app.example.com/path"),
-            &rules
-        ));
-        assert!(!is_url_allowed(
-            &url("https://notexample.com/path"),
-            &rules
-        ));
+        assert!(is_url_allowed(&url("https://app.example.com/path"), &rules));
+        assert!(!is_url_allowed(&url("https://notexample.com/path"), &rules));
     }
 
     #[test]
@@ -352,14 +346,8 @@ mod tests {
             &url("http://origin.example:8080/"),
             &[AllowUrl::parse("other.example").unwrap()],
         );
-        assert!(is_url_allowed(
-            &url("http://other.example:9090/"),
-            &rules
-        ));
-        assert!(is_url_allowed(
-            &url("http://other.example:8080/"),
-            &rules
-        ));
+        assert!(is_url_allowed(&url("http://other.example:9090/"), &rules));
+        assert!(is_url_allowed(&url("http://other.example:8080/"), &rules));
     }
 
     #[test]

--- a/lib/bombadil-browser/src/allow_url.rs
+++ b/lib/bombadil-browser/src/allow_url.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::path::PathBuf;
 
 use url::Url;
 
@@ -7,6 +8,9 @@ pub enum AllowUrl {
     /// The starting origin host. Added implicitly when the origin has a host;
     /// any path on this host is allowed.
     ExactHost { host: String, port: Option<u16> },
+    /// Exact `file://` path (absolute). Used for inspect / local HTML origins
+    /// and explicit `--allow-url file:///…` entries.
+    ExactFile { path: PathBuf },
     /// A registrable domain and its subdomains (e.g. `example.com`, `.example.com`).
     Domain { domain: String },
     /// A URL prefix: scheme, host, port, and path prefix must match.
@@ -28,6 +32,11 @@ impl AllowUrl {
         if raw.contains("://") {
             let url = Url::parse(raw)
                 .map_err(|err| format!("invalid allow-url {raw:?}: {err}"))?;
+            if url.scheme() == "file" {
+                return Ok(AllowUrl::ExactFile {
+                    path: absolute_file_path(&url)?,
+                });
+            }
             let host = url
                 .host_str()
                 .ok_or_else(|| format!("allow-url {raw:?} has no host"))?
@@ -45,29 +54,40 @@ impl AllowUrl {
         })
     }
 
-    /// Implicit allow rule for the test origin, if it has a network host.
+    /// Implicit allow rule for the test origin.
     ///
-    /// Origins without a host (e.g. `file://`) produce no rule. Host-less
-    /// *targets* (other than `about:` URLs) are handled in [`is_url_allowed`]:
-    /// allowed only when the origin is also host-less (inspect/`file://`).
-    /// Any `about:` URL is always out of bounds.
+    /// * Network origins → [`AllowUrl::ExactHost`] for that host (and port).
+    /// * `file://` origins → [`AllowUrl::ExactFile`] for that absolute path only.
+    /// * Other host-less origins → no implicit rule.
     pub fn from_origin(origin: &Url) -> Option<Self> {
+        if origin.scheme() == "file" {
+            return absolute_file_path(origin)
+                .ok()
+                .map(|path| AllowUrl::ExactFile { path });
+        }
         origin.host_str().map(|host| AllowUrl::ExactHost {
             host: host.to_string(),
             port: origin.port(),
         })
     }
 
-    fn matches(&self, uri: &Url, origin: &Url) -> bool {
+    /// Whether `uri` matches this rule. Rules are self-contained; they do not
+    /// consult a separate origin for ports or other fields.
+    fn matches(&self, uri: &Url) -> bool {
         match self {
             AllowUrl::ExactHost { host, port } => {
                 uri.host_str() == Some(host.as_str())
-                    && ports_match(uri.port(), *port, origin.port())
+                    && ports_match(uri.port(), *port)
             }
-            AllowUrl::Domain { domain } => {
-                if uri.port().is_some() && uri.port() != origin.port() {
+            AllowUrl::ExactFile { path } => {
+                if uri.scheme() != "file" {
                     return false;
                 }
+                absolute_file_path(uri)
+                    .map(|p| p == *path)
+                    .unwrap_or(false)
+            }
+            AllowUrl::Domain { domain } => {
                 let Some(uri_host) = uri.host_str() else {
                     return false;
                 };
@@ -81,20 +101,23 @@ impl AllowUrl {
             } => {
                 uri.scheme() == scheme
                     && uri.host_str() == Some(host.as_str())
-                    && ports_match(uri.port(), *port, *port)
+                    && ports_match(uri.port(), *port)
                     && path_matches_prefix(uri.path(), path_prefix)
             }
         }
     }
 }
 
-/// CLI / reproduce form. Only [`AllowUrl::Domain`] and [`AllowUrl::UrlPrefix`]
-/// are user-supplied; [`AllowUrl::ExactHost`] is implicit and not displayed.
+/// CLI / reproduce form. [`AllowUrl::ExactHost`] is origin-only and not displayed.
 impl Display for AllowUrl {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             AllowUrl::ExactHost { .. } => {
                 panic!("origin allow-url is implicit and not reproduced")
+            }
+            AllowUrl::ExactFile { path } => {
+                let url = Url::from_file_path(path).map_err(|_| std::fmt::Error)?;
+                write!(f, "{url}")
             }
             AllowUrl::Domain { domain } => write!(f, "{domain}"),
             AllowUrl::UrlPrefix {
@@ -125,23 +148,25 @@ pub fn build_allow_list(origin: &Url, extra: &[AllowUrl]) -> Vec<AllowUrl> {
     allow_urls
 }
 
-pub fn is_url_allowed(
-    uri: &Url,
-    allow_urls: &[AllowUrl],
-    origin: &Url,
-) -> bool {
+pub fn is_url_allowed(uri: &Url, allow_urls: &[AllowUrl]) -> bool {
     // about: URLs (blank, srcdoc, …) are tab setup or non-app chrome, never
     // exploration targets; out of bounds → Back only.
     if uri.scheme() == "about" {
         return false;
     }
-    // Other host-less URLs (typical file:// pages) have no network host to
-    // match against the allow-list. Allow them only when the test origin is
-    // also host-less (e.g. file:// inspect reports).
-    if uri.host().is_none() {
-        return origin.host().is_none();
+    allow_urls.iter().any(|rule| rule.matches(uri))
+}
+
+/// Absolute filesystem path for a `file://` URL.
+fn absolute_file_path(url: &Url) -> Result<PathBuf, String> {
+    if url.scheme() != "file" {
+        return Err(format!("expected file URL, got {}", url.scheme()));
     }
-    allow_urls.iter().any(|rule| rule.matches(uri, origin))
+    let path = url
+        .to_file_path()
+        .map_err(|()| format!("invalid file URL {url}"))?;
+    std::path::absolute(path)
+        .map_err(|err| format!("could not resolve absolute path for {url}: {err}"))
 }
 
 fn normalize_domain(domain: &str) -> String {
@@ -160,13 +185,9 @@ fn host_matches_domain(host: &str, domain: &str) -> bool {
     host == domain || host.ends_with(&format!(".{domain}"))
 }
 
-fn ports_match(
-    uri_port: Option<u16>,
-    rule_port: Option<u16>,
-    origin_port: Option<u16>,
-) -> bool {
-    let expected = rule_port.or(origin_port);
-    match (uri_port, expected) {
+/// Port constraint from the allow rule alone (no separate origin port).
+fn ports_match(uri_port: Option<u16>, rule_port: Option<u16>) -> bool {
+    match (uri_port, rule_port) {
         (Some(uri), Some(expected)) => uri == expected,
         (Some(_), None) => true,
         (None, _) => true,
@@ -203,8 +224,8 @@ mod tests {
         )
     }
 
-    /// Draw a network URL with a host (skip host-less / unparseable draws).
-    fn draw_network_url(tc: &TestCase) -> Url {
+    #[hegel::composite]
+    fn draw_network_url(tc: TestCase) -> Url {
         let u = Url::parse(&tc.draw(urls())).unwrap_or_else(|_| tc.reject());
         if u.host_str().is_none() {
             tc.reject();
@@ -212,10 +233,9 @@ mod tests {
         u
     }
 
-    /// Build a user-facing [`AllowUrl`] (Domain or UrlPrefix) field-by-field from
-    /// a network URL.
-    fn draw_allow_url(tc: &TestCase) -> AllowUrl {
-        let seed = draw_network_url(tc);
+    #[hegel::composite]
+    fn draw_allow_url(tc: TestCase) -> AllowUrl {
+        let seed = tc.draw(draw_network_url());
         let host = seed.host_str().unwrap().to_string();
         if tc.draw(booleans()) {
             AllowUrl::Domain { domain: host }
@@ -230,105 +250,121 @@ mod tests {
     }
 
     #[test]
-    fn file_origin_allows_other_file_urls_but_not_about_blank() {
+    fn file_origin_allows_exact_path_only() {
         let origin = url("file:///tmp/index.html");
         let rules = build_allow_list(&origin, &[]);
-        assert!(rules.is_empty());
-        assert!(AllowUrl::from_origin(&origin).is_none());
-        assert!(is_url_allowed(
-            &url("file:///tmp/other.html"),
-            &rules,
-            &origin
-        ));
-        // about: URLs are never exploration targets.
-        assert!(!is_url_allowed(&url("about:blank"), &rules, &origin));
-        assert!(!is_url_allowed(
-            &url("https://example.com/"),
-            &rules,
-            &origin
-        ));
+        assert_eq!(rules.len(), 1);
+        assert!(matches!(&rules[0], AllowUrl::ExactFile { .. }));
+
+        let origin_path = absolute_file_path(&origin).unwrap();
+        let origin_url =
+            Url::from_file_path(&origin_path).expect("file path to url");
+        assert!(is_url_allowed(&origin_url, &rules));
+
+        // Sibling file path is not implied; allow only exact origin path.
+        let other = url("file:///tmp/other.html");
+        assert!(!is_url_allowed(&other, &rules));
+
+        assert!(!is_url_allowed(&url("about:blank"), &rules));
+        assert!(!is_url_allowed(&url("https://example.com/"), &rules));
+    }
+
+    #[test]
+    fn file_allow_url_is_exact_match() {
+        let origin = url("https://example.com/");
+        let allowed = url("file:///tmp/allowed.html");
+        let allowed_abs = Url::from_file_path(absolute_file_path(&allowed).unwrap())
+            .unwrap();
+        let rules = build_allow_list(
+            &origin,
+            &[AllowUrl::parse(allowed_abs.as_str()).unwrap()],
+        );
+        assert!(is_url_allowed(&allowed_abs, &rules));
+        assert!(!is_url_allowed(&url("file:///tmp/other.html"), &rules));
     }
 
     #[test]
     fn about_scheme_is_always_out_of_bounds() {
-        let network = url("http://localhost:1073/");
         let network_rules = allow("http://localhost:1073/", &[]);
-        assert!(!is_url_allowed(
-            &url("about:blank"),
-            &network_rules,
-            &network
-        ));
-        assert!(!is_url_allowed(
-            &url("about:srcdoc"),
-            &network_rules,
-            &network
-        ));
+        assert!(!is_url_allowed(&url("about:blank"), &network_rules));
+        assert!(!is_url_allowed(&url("about:srcdoc"), &network_rules));
 
         let file = url("file:///tmp/index.html");
         let file_rules = build_allow_list(&file, &[]);
-        assert!(!is_url_allowed(&url("about:blank"), &file_rules, &file));
-        assert!(!is_url_allowed(&url("about:srcdoc"), &file_rules, &file));
-    }
-
-    #[test]
-    fn network_origin_rejects_file_urls() {
-        let origin = url("http://localhost:1073/");
-        let rules = allow("http://localhost:1073/", &[]);
-        assert!(!is_url_allowed(
-            &url("file:///tmp/other.html"),
-            &rules,
-            &origin
-        ));
+        assert!(!is_url_allowed(&url("about:blank"), &file_rules));
+        assert!(!is_url_allowed(&url("about:srcdoc"), &file_rules));
     }
 
     #[test]
     fn origin_only_allows_same_host() {
-        let origin = url("https://example.com/app");
         let rules = allow("https://example.com/app", &[]);
-        assert!(is_url_allowed(
-            &url("https://example.com/other"),
-            &rules,
-            &origin
-        ));
+        assert!(is_url_allowed(&url("https://example.com/other"), &rules));
         assert!(!is_url_allowed(
             &url("https://app.example.com/other"),
-            &rules,
-            &origin
+            &rules
         ));
     }
 
     #[test]
     fn domain_entry_allows_subdomains() {
-        let origin = url("https://example.com/");
         let rules = allow("https://example.com/", &[".example.com"]);
         assert!(is_url_allowed(
             &url("https://app.example.com/path"),
-            &rules,
-            &origin
+            &rules
         ));
         assert!(!is_url_allowed(
             &url("https://notexample.com/path"),
-            &rules,
-            &origin
+            &rules
+        ));
+    }
+
+    #[test]
+    fn domain_entry_does_not_reuse_origin_port() {
+        // Origin port must not constrain a Domain rule (Oskar's example).
+        let rules = build_allow_list(
+            &url("http://origin.example:8080/"),
+            &[AllowUrl::parse("other.example").unwrap()],
+        );
+        assert!(is_url_allowed(
+            &url("http://other.example:9090/"),
+            &rules
+        ));
+        assert!(is_url_allowed(
+            &url("http://other.example:8080/"),
+            &rules
+        ));
+    }
+
+    #[test]
+    fn url_prefix_port_is_self_contained() {
+        // allow-url http://other:9090 must not accept other:8080 via origin port.
+        let rules = build_allow_list(
+            &url("http://origin.example:8080/"),
+            &[AllowUrl::parse("http://other.example:9090/").unwrap()],
+        );
+        assert!(is_url_allowed(
+            &url("http://other.example:9090/path"),
+            &rules
+        ));
+        assert!(!is_url_allowed(
+            &url("http://other.example:8080/path"),
+            &rules
         ));
     }
 
     #[test]
     fn url_prefix_entry_allows_scoped_paths() {
-        let origin = url("https://other.example.com/");
         let rules = allow(
             "https://other.example.com/",
             &["https://example.com/my/cool/feature"],
         );
         assert!(is_url_allowed(
             &url("https://example.com/my/cool/feature/extra"),
-            &rules,
-            &origin
+            &rules
         ));
         assert!(!is_url_allowed(
             &url("https://example.com/my/cool/features"),
-            &rules,
-            &origin
+            &rules
         ));
     }
 
@@ -353,25 +389,23 @@ mod tests {
 
     #[hegel::test]
     fn roundtrip_display_parse(tc: TestCase) {
-        let allow = draw_allow_url(&tc);
+        let allow = tc.draw(draw_allow_url());
         let formatted = format!("{allow}");
         let parsed = AllowUrl::parse(&formatted).unwrap();
         assert_eq!(parsed, allow);
     }
 
-    /// Given Url `u` that parses as AllowUrl `a`, `is_url_allowed(u, &[a], origin)`.
-    /// Origin is `u` so Domain's port check against origin does not fail.
+    /// Given Url `u` that parses as AllowUrl `a`, `is_url_allowed(u, &[a])`.
     #[hegel::test]
     fn is_url_allowed_when_parsed_from_url(tc: TestCase) {
-        let u = draw_network_url(&tc);
-        // Domain form (host only) or full URL form — both are valid --allow-url inputs.
+        let u = tc.draw(draw_network_url());
         let a = if tc.draw(booleans()) {
             AllowUrl::parse(u.host_str().unwrap()).unwrap()
         } else {
             AllowUrl::parse(u.as_str()).unwrap_or_else(|_| tc.reject())
         };
         assert!(
-            is_url_allowed(&u, std::slice::from_ref(&a), &u),
+            is_url_allowed(&u, std::slice::from_ref(&a)),
             "url {u} should be allowed by {a}"
         );
     }

--- a/lib/bombadil-browser/src/allow_url.rs
+++ b/lib/bombadil-browser/src/allow_url.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
 use url::Url;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -57,31 +59,6 @@ impl AllowUrl {
         })
     }
 
-    pub fn cli_value(&self) -> String {
-        match self {
-            AllowUrl::ExactHost { .. } => {
-                panic!("origin allow-url is implicit and not reproduced")
-            }
-            AllowUrl::Domain { domain } => domain.clone(),
-            AllowUrl::UrlPrefix {
-                scheme,
-                host,
-                port,
-                path_prefix,
-            } => {
-                let mut url = format!("{scheme}://{host}");
-                if let Some(port) = port {
-                    url.push(':');
-                    url.push_str(&port.to_string());
-                }
-                if path_prefix != "/" {
-                    url.push_str(path_prefix);
-                }
-                url
-            }
-        }
-    }
-
     fn matches(&self, uri: &Url, origin: &Url) -> bool {
         match self {
             AllowUrl::ExactHost { host, port } => {
@@ -107,6 +84,34 @@ impl AllowUrl {
                     && uri.host_str() == Some(host.as_str())
                     && ports_match(uri.port(), *port, *port)
                     && path_matches_prefix(uri.path(), path_prefix)
+            }
+        }
+    }
+}
+
+/// CLI / reproduce form. Only [`AllowUrl::Domain`] and [`AllowUrl::UrlPrefix`]
+/// are user-supplied; [`AllowUrl::ExactHost`] is implicit and not displayed.
+impl Display for AllowUrl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            AllowUrl::ExactHost { .. } => {
+                panic!("origin allow-url is implicit and not reproduced")
+            }
+            AllowUrl::Domain { domain } => write!(f, "{domain}"),
+            AllowUrl::UrlPrefix {
+                scheme,
+                host,
+                port,
+                path_prefix,
+            } => {
+                write!(f, "{scheme}://{host}")?;
+                if let Some(port) = port {
+                    write!(f, ":{port}")?;
+                }
+                if path_prefix != "/" {
+                    write!(f, "{path_prefix}")?;
+                }
+                Ok(())
             }
         }
     }
@@ -174,6 +179,10 @@ fn path_matches_prefix(path: &str, prefix: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hegel::{
+        TestCase,
+        generators::{booleans, urls},
+    };
 
     fn url(s: &str) -> Url {
         Url::parse(s).unwrap()
@@ -188,6 +197,32 @@ mod tests {
                 .map(|raw| AllowUrl::parse(raw).unwrap())
                 .collect::<Vec<_>>(),
         )
+    }
+
+    /// Draw a network URL with a host (skip host-less / unparseable draws).
+    fn draw_network_url(tc: &TestCase) -> Url {
+        let u = Url::parse(&tc.draw(urls())).unwrap_or_else(|_| tc.reject());
+        if u.host_str().is_none() {
+            tc.reject();
+        }
+        u
+    }
+
+    /// Build a user-facing [`AllowUrl`] (Domain or UrlPrefix) field-by-field from
+    /// a network URL.
+    fn draw_allow_url(tc: &TestCase) -> AllowUrl {
+        let seed = draw_network_url(tc);
+        let host = seed.host_str().unwrap().to_string();
+        if tc.draw(booleans()) {
+            AllowUrl::Domain { domain: host }
+        } else {
+            AllowUrl::UrlPrefix {
+                scheme: seed.scheme().to_string(),
+                host,
+                port: seed.port(),
+                path_prefix: normalize_path_prefix(seed.path()),
+            }
+        }
     }
 
     #[test]
@@ -285,6 +320,38 @@ mod tests {
                 port: None,
                 path_prefix: "/my/cool/feature".into(),
             }
+        );
+    }
+
+    #[hegel::test]
+    fn roundtrip_display_parse(tc: TestCase) {
+        let allow = draw_allow_url(&tc);
+        let formatted = format!("{allow}");
+        let parsed = AllowUrl::parse(&formatted).unwrap();
+        assert_eq!(parsed, allow);
+    }
+
+    /// An allow-url built from a URL's fields allows that URL.
+    /// Origin is the same URL so Domain's port check against origin does not fail.
+    #[hegel::test]
+    fn allow_url_allows_matching_url(tc: TestCase) {
+        let seed = draw_network_url(&tc);
+        let host = seed.host_str().unwrap().to_string();
+        let allow = if tc.draw(booleans()) {
+            AllowUrl::Domain {
+                domain: host.clone(),
+            }
+        } else {
+            AllowUrl::UrlPrefix {
+                scheme: seed.scheme().to_string(),
+                host,
+                port: seed.port(),
+                path_prefix: normalize_path_prefix(seed.path()),
+            }
+        };
+        assert!(
+            is_url_allowed(&seed, std::slice::from_ref(&allow), &seed),
+            "url {seed} should be allowed by {allow}"
         );
     }
 }

--- a/lib/bombadil-browser/src/allow_url.rs
+++ b/lib/bombadil-browser/src/allow_url.rs
@@ -4,6 +4,8 @@ use url::Url;
 pub enum AllowUrl {
     /// The starting origin host. Added implicitly; any path on this host is allowed.
     ExactHost { host: String, port: Option<u16> },
+    /// Origin without a network host (e.g. file://).
+    Hostless { port: Option<u16> },
     /// A registrable domain and its subdomains (e.g. `example.com`, `.example.com`).
     Domain { domain: String },
     /// A URL prefix: scheme, host, port, and path prefix must match.
@@ -43,18 +45,20 @@ impl AllowUrl {
     }
 
     pub fn from_origin(origin: &Url) -> Self {
-        AllowUrl::ExactHost {
-            host: origin
-                .host_str()
-                .expect("origin URL has no host")
-                .to_string(),
-            port: origin.port(),
+        match origin.host_str() {
+            Some(host) => AllowUrl::ExactHost {
+                host: host.to_string(),
+                port: origin.port(),
+            },
+            None => AllowUrl::Hostless {
+                port: origin.port(),
+            },
         }
     }
 
     pub fn cli_value(&self) -> String {
         match self {
-            AllowUrl::ExactHost { .. } => {
+            AllowUrl::ExactHost { .. } | AllowUrl::Hostless { .. } => {
                 panic!("origin allow-url is implicit and not reproduced")
             }
             AllowUrl::Domain { domain } => domain.clone(),
@@ -81,6 +85,10 @@ impl AllowUrl {
         match self {
             AllowUrl::ExactHost { host, port } => {
                 uri.host_str() == Some(host.as_str())
+                    && ports_match(uri.port(), *port, origin.port())
+            }
+            AllowUrl::Hostless { port } => {
+                uri.host().is_none()
                     && ports_match(uri.port(), *port, origin.port())
             }
             AllowUrl::Domain { domain } => {
@@ -180,6 +188,23 @@ mod tests {
                 .map(|raw| AllowUrl::parse(raw).unwrap())
                 .collect::<Vec<_>>(),
         )
+    }
+
+    #[test]
+    fn file_origin_allows_hostless_urls() {
+        let origin = url("file:///tmp/index.html");
+        let rules = build_allow_list(&origin, &[]);
+        assert!(matches!(rules[0], AllowUrl::Hostless { .. }));
+        assert!(is_url_allowed(
+            &url("file:///tmp/other.html"),
+            &rules,
+            &origin
+        ));
+        assert!(!is_url_allowed(
+            &url("https://example.com/"),
+            &rules,
+            &origin
+        ));
     }
 
     #[test]

--- a/lib/bombadil-browser/src/allow_url.rs
+++ b/lib/bombadil-browser/src/allow_url.rs
@@ -1,0 +1,249 @@
+use url::Url;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AllowUrl {
+    /// The starting origin host. Added implicitly; any path on this host is allowed.
+    ExactHost { host: String, port: Option<u16> },
+    /// A registrable domain and its subdomains (e.g. `example.com`, `.example.com`).
+    Domain { domain: String },
+    /// A URL prefix: scheme, host, port, and path prefix must match.
+    UrlPrefix {
+        scheme: String,
+        host: String,
+        port: Option<u16>,
+        path_prefix: String,
+    },
+}
+
+impl AllowUrl {
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Err("allow-url must not be empty".into());
+        }
+
+        if raw.contains("://") {
+            let url = Url::parse(raw)
+                .map_err(|err| format!("invalid allow-url {raw:?}: {err}"))?;
+            let host = url
+                .host_str()
+                .ok_or_else(|| format!("allow-url {raw:?} has no host"))?
+                .to_string();
+            return Ok(AllowUrl::UrlPrefix {
+                scheme: url.scheme().to_string(),
+                host,
+                port: url.port(),
+                path_prefix: normalize_path_prefix(url.path()),
+            });
+        }
+
+        Ok(AllowUrl::Domain {
+            domain: normalize_domain(raw),
+        })
+    }
+
+    pub fn from_origin(origin: &Url) -> Self {
+        AllowUrl::ExactHost {
+            host: origin
+                .host_str()
+                .expect("origin URL has no host")
+                .to_string(),
+            port: origin.port(),
+        }
+    }
+
+    pub fn cli_value(&self) -> String {
+        match self {
+            AllowUrl::ExactHost { .. } => {
+                panic!("origin allow-url is implicit and not reproduced")
+            }
+            AllowUrl::Domain { domain } => domain.clone(),
+            AllowUrl::UrlPrefix {
+                scheme,
+                host,
+                port,
+                path_prefix,
+            } => {
+                let mut url = format!("{scheme}://{host}");
+                if let Some(port) = port {
+                    url.push(':');
+                    url.push_str(&port.to_string());
+                }
+                if path_prefix != "/" {
+                    url.push_str(path_prefix);
+                }
+                url
+            }
+        }
+    }
+
+    fn matches(&self, uri: &Url, origin: &Url) -> bool {
+        match self {
+            AllowUrl::ExactHost { host, port } => {
+                uri.host_str() == Some(host.as_str())
+                    && ports_match(uri.port(), *port, origin.port())
+            }
+            AllowUrl::Domain { domain } => {
+                if uri.port().is_some() && uri.port() != origin.port() {
+                    return false;
+                }
+                let uri_host = match uri.host_str() {
+                    Some(host) => host,
+                    None => return uri.host().is_none(),
+                };
+                host_matches_domain(uri_host, domain)
+            }
+            AllowUrl::UrlPrefix {
+                scheme,
+                host,
+                port,
+                path_prefix,
+            } => {
+                uri.scheme() == scheme
+                    && uri.host_str() == Some(host.as_str())
+                    && ports_match(uri.port(), *port, *port)
+                    && path_matches_prefix(uri.path(), path_prefix)
+            }
+        }
+    }
+}
+
+pub fn build_allow_list(origin: &Url, extra: &[AllowUrl]) -> Vec<AllowUrl> {
+    let mut allow_urls = vec![AllowUrl::from_origin(origin)];
+    allow_urls.extend(extra.iter().cloned());
+    allow_urls
+}
+
+pub fn is_url_allowed(
+    uri: &Url,
+    allow_urls: &[AllowUrl],
+    origin: &Url,
+) -> bool {
+    allow_urls.iter().any(|rule| rule.matches(uri, origin))
+}
+
+fn normalize_domain(domain: &str) -> String {
+    domain.trim_start_matches('.').to_string()
+}
+
+fn normalize_path_prefix(path: &str) -> String {
+    if path.is_empty() {
+        "/".to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+fn host_matches_domain(host: &str, domain: &str) -> bool {
+    host == domain || host.ends_with(&format!(".{domain}"))
+}
+
+fn ports_match(
+    uri_port: Option<u16>,
+    rule_port: Option<u16>,
+    origin_port: Option<u16>,
+) -> bool {
+    let expected = rule_port.or(origin_port);
+    match (uri_port, expected) {
+        (Some(uri), Some(expected)) => uri == expected,
+        (Some(_), None) => true,
+        (None, _) => true,
+    }
+}
+
+fn path_matches_prefix(path: &str, prefix: &str) -> bool {
+    if prefix == "/" {
+        return true;
+    }
+    path == prefix || path.starts_with(&format!("{prefix}/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn url(s: &str) -> Url {
+        Url::parse(s).unwrap()
+    }
+
+    fn allow(origin: &str, extra: &[&str]) -> Vec<AllowUrl> {
+        let origin = url(origin);
+        build_allow_list(
+            &origin,
+            &extra
+                .iter()
+                .map(|raw| AllowUrl::parse(raw).unwrap())
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn origin_only_allows_same_host() {
+        let origin = url("https://example.com/app");
+        let rules = allow("https://example.com/app", &[]);
+        assert!(is_url_allowed(
+            &url("https://example.com/other"),
+            &rules,
+            &origin
+        ));
+        assert!(!is_url_allowed(
+            &url("https://app.example.com/other"),
+            &rules,
+            &origin
+        ));
+    }
+
+    #[test]
+    fn domain_entry_allows_subdomains() {
+        let origin = url("https://example.com/");
+        let rules = allow("https://example.com/", &[".example.com"]);
+        assert!(is_url_allowed(
+            &url("https://app.example.com/path"),
+            &rules,
+            &origin
+        ));
+        assert!(!is_url_allowed(
+            &url("https://notexample.com/path"),
+            &rules,
+            &origin
+        ));
+    }
+
+    #[test]
+    fn url_prefix_entry_allows_scoped_paths() {
+        let origin = url("https://other.example.com/");
+        let rules = allow(
+            "https://other.example.com/",
+            &["https://example.com/my/cool/feature"],
+        );
+        assert!(is_url_allowed(
+            &url("https://example.com/my/cool/feature/extra"),
+            &rules,
+            &origin
+        ));
+        assert!(!is_url_allowed(
+            &url("https://example.com/my/cool/features"),
+            &rules,
+            &origin
+        ));
+    }
+
+    #[test]
+    fn parse_domain_and_url_forms() {
+        assert_eq!(
+            AllowUrl::parse("example.com").unwrap(),
+            AllowUrl::Domain {
+                domain: "example.com".into()
+            }
+        );
+        assert_eq!(
+            AllowUrl::parse("https://example.com/my/cool/feature").unwrap(),
+            AllowUrl::UrlPrefix {
+                scheme: "https".into(),
+                host: "example.com".into(),
+                port: None,
+                path_prefix: "/my/cool/feature".into(),
+            }
+        );
+    }
+}

--- a/lib/bombadil-browser/src/allow_url.rs
+++ b/lib/bombadil-browser/src/allow_url.rs
@@ -119,6 +119,11 @@ pub fn is_url_allowed(
     allow_urls: &[AllowUrl],
     origin: &Url,
 ) -> bool {
+    // Preserve the previous origin-boundary behavior for host-less URLs (e.g.
+    // about:blank while a page is loading or reloading).
+    if uri.host().is_none() {
+        return uri.port().is_none() || uri.port() == origin.port();
+    }
     allow_urls.iter().any(|rule| rule.matches(uri, origin))
 }
 
@@ -175,6 +180,13 @@ mod tests {
                 .map(|raw| AllowUrl::parse(raw).unwrap())
                 .collect::<Vec<_>>(),
         )
+    }
+
+    #[test]
+    fn hostless_urls_are_allowed() {
+        let origin = url("http://localhost:1073/");
+        let rules = allow("http://localhost:1073/", &[]);
+        assert!(is_url_allowed(&url("about:blank"), &rules, &origin));
     }
 
     #[test]

--- a/lib/bombadil-browser/src/allow_url.rs
+++ b/lib/bombadil-browser/src/allow_url.rs
@@ -5,8 +5,8 @@ use url::Url;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AllowUrl {
-    /// The starting origin host. Added implicitly when the origin has a host;
-    /// any path on this host is allowed.
+    /// The starting origin host (any path). Used as the default boundary when
+    /// no explicit `--allow-url` entries are given.
     ExactHost { host: String, port: Option<u16> },
     /// Exact `file://` path (absolute). Used for inspect / local HTML origins
     /// and explicit `--allow-url file:///…` entries.
@@ -139,13 +139,17 @@ impl Display for AllowUrl {
     }
 }
 
+/// Build the exploration allow-list.
+///
+/// * No explicit entries → default to the origin only ([`AllowUrl::from_origin`]).
+/// * One or more `--allow-url` entries → those alone (replace, do not widen).
+///   Include the origin in `--allow-url` if it should remain in bounds.
 pub fn build_allow_list(origin: &Url, extra: &[AllowUrl]) -> Vec<AllowUrl> {
-    let mut allow_urls = Vec::new();
-    if let Some(origin_rule) = AllowUrl::from_origin(origin) {
-        allow_urls.push(origin_rule);
+    if extra.is_empty() {
+        AllowUrl::from_origin(origin).into_iter().collect()
+    } else {
+        extra.to_vec()
     }
-    allow_urls.extend(extra.iter().cloned());
-    allow_urls
 }
 
 pub fn is_url_allowed(uri: &Url, allow_urls: &[AllowUrl]) -> bool {
@@ -303,6 +307,29 @@ mod tests {
             &url("https://app.example.com/other"),
             &rules
         ));
+    }
+
+    #[test]
+    fn explicit_allow_url_replaces_origin_default() {
+        // With --allow-url, origin is not implicitly kept.
+        let rules = build_allow_list(
+            &url("https://origin.example/"),
+            &[AllowUrl::parse("https://allowed.example/app").unwrap()],
+        );
+        assert_eq!(rules.len(), 1);
+        assert!(!is_url_allowed(&url("https://origin.example/"), &rules));
+        assert!(is_url_allowed(
+            &url("https://allowed.example/app/page"),
+            &rules
+        ));
+    }
+
+    #[test]
+    fn empty_allow_url_keeps_origin_default() {
+        let rules = build_allow_list(&url("https://origin.example/"), &[]);
+        assert_eq!(rules.len(), 1);
+        assert!(matches!(&rules[0], AllowUrl::ExactHost { .. }));
+        assert!(is_url_allowed(&url("https://origin.example/x"), &rules));
     }
 
     #[test]

--- a/lib/bombadil-browser/src/allow_url.rs
+++ b/lib/bombadil-browser/src/allow_url.rs
@@ -132,10 +132,10 @@ pub fn is_url_allowed(
     origin: &Url,
 ) -> bool {
     // Host-less targets (about:blank mid-navigation, file:// pages, etc.) are
-    // always treated as in-bounds so the action set does not go empty. This is
-    // separate from the allow-list rules, which only apply to networked hosts.
+    // always in-bounds so we do not hit "no actions available" between
+    // navigations. Separate from the allow-list rules (network hosts only).
     if uri.host().is_none() {
-        return uri.port().is_none() || uri.port() == origin.port();
+        return true;
     }
     allow_urls.iter().any(|rule| rule.matches(uri, origin))
 }

--- a/lib/bombadil-browser/src/lib.rs
+++ b/lib/bombadil-browser/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod allow_url;
 pub mod browser;
 pub mod convert;
 pub mod driver;

--- a/lib/bombadil-browser/src/strategy.rs
+++ b/lib/bombadil-browser/src/strategy.rs
@@ -1,6 +1,6 @@
+use crate::allow_url::is_url_allowed;
 use crate::browser::actions::BrowserActionTemplate;
 use crate::render::format_action;
-use crate::url::is_within_domain;
 use anyhow::{Result, bail};
 use bombadil::render::format_timestamp;
 use bombadil::runner::PropertiesState;
@@ -41,6 +41,7 @@ pub struct TestStrategy<Writer: TraceWriter, Rng> {
     pub test_start: Option<bombadil_schema::Time>,
     pub deadline: Option<SystemTime>,
     pub origin: Url,
+    pub allow_urls: Vec<crate::allow_url::AllowUrl>,
     pub output_path: PathBuf,
     pub violations_count: u64,
 }
@@ -66,13 +67,14 @@ impl<Writer: TraceWriter, Rng: TryRng + RngExt> TestStrategy<Writer, Rng> {
         state: &BrowserState,
         tree: Tree<BrowserActionTemplate>,
     ) -> Result<BrowserAction> {
-        let tree = if is_within_domain(&state.url, &self.origin) {
-            tree
-        } else {
-            tree.filter(&|a| matches!(a, BrowserAction::Back))
-        }
-        .prune()
-        .ok_or_else(|| anyhow::anyhow!("no actions available"))?;
+        let tree =
+            if is_url_allowed(&state.url, &self.allow_urls, &self.origin) {
+                tree
+            } else {
+                tree.filter(&|a| matches!(a, BrowserAction::Back))
+            }
+            .prune()
+            .ok_or_else(|| anyhow::anyhow!("no actions available"))?;
 
         match &mut self.mode {
             TestMode::RandomWalk => {

--- a/lib/bombadil-browser/src/strategy.rs
+++ b/lib/bombadil-browser/src/strategy.rs
@@ -68,7 +68,7 @@ impl<Writer: TraceWriter, Rng: TryRng + RngExt> TestStrategy<Writer, Rng> {
         tree: Tree<BrowserActionTemplate>,
     ) -> Result<BrowserAction> {
         let tree =
-            if is_url_allowed(&state.url, &self.allow_urls, &self.origin) {
+            if is_url_allowed(&state.url, &self.allow_urls) {
                 tree
             } else {
                 tree.filter(&|a| matches!(a, BrowserAction::Back))

--- a/lib/bombadil-browser/src/strategy.rs
+++ b/lib/bombadil-browser/src/strategy.rs
@@ -67,14 +67,13 @@ impl<Writer: TraceWriter, Rng: TryRng + RngExt> TestStrategy<Writer, Rng> {
         state: &BrowserState,
         tree: Tree<BrowserActionTemplate>,
     ) -> Result<BrowserAction> {
-        let tree =
-            if is_url_allowed(&state.url, &self.allow_urls) {
-                tree
-            } else {
-                tree.filter(&|a| matches!(a, BrowserAction::Back))
-            }
-            .prune()
-            .ok_or_else(|| anyhow::anyhow!("no actions available"))?;
+        let tree = if is_url_allowed(&state.url, &self.allow_urls) {
+            tree
+        } else {
+            tree.filter(&|a| matches!(a, BrowserAction::Back))
+        }
+        .prune()
+        .ok_or_else(|| anyhow::anyhow!("no actions available"))?;
 
         match &mut self.mode {
             TestMode::RandomWalk => {

--- a/lib/bombadil-browser/src/url.rs
+++ b/lib/bombadil-browser/src/url.rs
@@ -1,14 +1,6 @@
 use anyhow::{Result, anyhow};
 use url::Url;
 
-use crate::allow_url::{build_allow_list, is_url_allowed};
-
-pub fn is_within_domain(uri: &Url, domain: &Url) -> bool {
-    is_url_allowed(uri, &build_allow_list(domain, &[]), domain)
-}
-
-pub use crate::allow_url::AllowUrl;
-
 #[allow(unused, reason = "porting this to js scripts")]
 pub fn parse_browser_url(string: &str, context: &Url) -> Result<Url> {
     context.join(string).map_err(|err| anyhow!(err))

--- a/lib/bombadil-browser/src/url.rs
+++ b/lib/bombadil-browser/src/url.rs
@@ -1,10 +1,13 @@
 use anyhow::{Result, anyhow};
 use url::Url;
 
+use crate::allow_url::{build_allow_list, is_url_allowed};
+
 pub fn is_within_domain(uri: &Url, domain: &Url) -> bool {
-    (uri.host().is_none() || uri.host() == domain.host())
-        && (uri.port().is_none() || uri.port() == domain.port())
+    is_url_allowed(uri, &build_allow_list(domain, &[]), domain)
 }
+
+pub use crate::allow_url::AllowUrl;
 
 #[allow(unused, reason = "porting this to js scripts")]
 pub fn parse_browser_url(string: &str, context: &Url) -> Result<Url> {

--- a/lib/bombadil-cli/build.rs
+++ b/lib/bombadil-cli/build.rs
@@ -32,13 +32,27 @@ fn build_inspect(dist_directory: &Path) {
     let mut command = std::process::Command::new("trunk");
     command
         .arg("build")
+        // trunk 0.21 treats --offline as optional true/false; pass explicitly.
         .arg("--offline")
+        .arg("true")
         .arg("--dist")
         .arg(&dist_absolute)
         .env("CARGO_TARGET_DIR", &wasm_target_directory)
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .current_dir(inspect_directory);
+
+    // Trunk 0.21 maps NO_COLOR to --no-color and only accepts true/false.
+    // Normalize common truthy values (e.g. "1") so the child does not fail.
+    match std::env::var("NO_COLOR") {
+        Ok(value) if is_truthy(&value) => {
+            command.env("NO_COLOR", "true");
+        }
+        Ok(_) => {
+            command.env_remove("NO_COLOR");
+        }
+        Err(_) => {}
+    }
 
     let profile = std::env::var("PROFILE").unwrap_or_default();
     if profile == "release" {
@@ -50,6 +64,19 @@ fn build_inspect(dist_directory: &Path) {
     if !status.success() {
         panic!("cargo:warning=trunk build failed");
     }
+}
+
+/// Whether an env value should be treated as enabling NO_COLOR (non-empty and
+/// not an explicit false-like token).
+fn is_truthy(value: &str) -> bool {
+    let value = value.trim();
+    if value.is_empty() {
+        return false;
+    }
+    !matches!(
+        value.to_ascii_lowercase().as_str(),
+        "0" | "false" | "no" | "off"
+    )
 }
 
 fn ensure_placeholder(dist_directory: &Path) {

--- a/lib/bombadil-cli/src/browser.rs
+++ b/lib/bombadil-cli/src/browser.rs
@@ -342,7 +342,7 @@ fn reproduce_command_args(
         args.push(format!("--cookie {cookie}"));
     }
     for allow_url in &shared.allow_urls {
-        args.push(format!("--allow-url {}", allow_url.cli_value()));
+        args.push(format!("--allow-url {allow_url}"));
     }
     args
 }

--- a/lib/bombadil-cli/src/browser.rs
+++ b/lib/bombadil-cli/src/browser.rs
@@ -80,9 +80,9 @@ pub enum BrowserCommand {
 
 #[derive(Args)]
 pub struct TestSharedOptions {
-    /// Starting URL of the test (also used as a boundary so that Bombadil doesn't navigate to
-    /// other websites). The origin host is always allowed; use `--allow-url` to widen the
-    /// boundary to other domains or path prefixes.
+    /// Starting URL of the test. Without `--allow-url`, exploration stays on this origin host.
+    /// With one or more `--allow-url` entries, those define the boundary instead (include the
+    /// origin there if it should remain allowed).
     pub origin: Origin,
     /// A custom specification in TypeScript or JavaScript, using the `@antithesishq/bombadil`
     /// package on NPM
@@ -132,10 +132,10 @@ pub struct TestSharedOptions {
     /// browser cookies. Can be specified multiple times.
     #[arg(long = "cookie", value_name = "SET-COOKIE", value_parser = parse_cookie)]
     pub cookies: Vec<BrowserCookie>,
-    /// Additional URL or domain where exploration is allowed. The origin is always included.
+    /// Exploration boundary (replaces the default origin-only rule when set).
     /// Domains (e.g. `example.com`, `.example.com`) allow that host and its subdomains.
     /// URLs (e.g. `https://example.com/my/feature`) allow prefix-matched paths on that host.
-    /// Can be specified multiple times.
+    /// `file://` paths match exactly (absolute). Can be specified multiple times.
     #[arg(long = "allow-url", value_name = "URL_OR_DOMAIN", value_parser = parse_allow_url)]
     pub allow_urls: Vec<AllowUrl>,
     /// Reproduce a previous test run from a trace file, instead of random exploration.

--- a/lib/bombadil-cli/src/browser.rs
+++ b/lib/bombadil-cli/src/browser.rs
@@ -17,6 +17,7 @@ use tokio::{fs::File, io::BufReader};
 
 use bombadil::{specification::verifier::Specification, styled};
 use bombadil_browser::{
+    allow_url::{AllowUrl, build_allow_list},
     browser::{
         BrowserOptions, DebuggerOptions, Emulation, actions::BrowserAction,
     },
@@ -76,7 +77,8 @@ pub enum BrowserCommand {
 #[derive(Args)]
 pub struct TestSharedOptions {
     /// Starting URL of the test (also used as a boundary so that Bombadil doesn't navigate to
-    /// other websites)
+    /// other websites). The origin host is always allowed; use `--allow-url` to widen the
+    /// boundary to other domains or path prefixes.
     pub origin: Origin,
     /// A custom specification in TypeScript or JavaScript, using the `@antithesishq/bombadil`
     /// package on NPM
@@ -126,6 +128,12 @@ pub struct TestSharedOptions {
     /// static request header. Can be specified multiple times.
     #[arg(long = "cookie", value_name = "NAME=VALUE", value_parser = parse_header)]
     pub cookies: Vec<(String, String)>,
+    /// Additional URL or domain where exploration is allowed. The origin is always included.
+    /// Domains (e.g. `example.com`, `.example.com`) allow that host and its subdomains.
+    /// URLs (e.g. `https://example.com/my/feature`) allow prefix-matched paths on that host.
+    /// Can be specified multiple times.
+    #[arg(long = "allow-url", value_name = "URL_OR_DOMAIN", value_parser = parse_allow_url)]
+    pub allow_urls: Vec<AllowUrl>,
     /// Reproduce a previous test run from a trace file, instead of random exploration.
     /// Mutually exclusive with --time-limit and --exit-on-violation.
     #[arg(long, value_name = "TRACE_FILE", conflicts_with_all = ["time_limit", "exit_on_violation"])]
@@ -241,6 +249,10 @@ fn parse_header(s: &str) -> std::result::Result<(String, String), String> {
         .ok_or_else(|| format!("invalid header {:?}, expected KEY=VALUE", s))
 }
 
+fn parse_allow_url(s: &str) -> std::result::Result<AllowUrl, String> {
+    AllowUrl::parse(s)
+}
+
 fn parse_instrumentation_config(
     s: &str,
 ) -> std::result::Result<InstrumentationConfig, String> {
@@ -324,6 +336,9 @@ fn reproduce_command_args(
     for (name, value) in &shared.cookies {
         args.push(format!("--cookie {name}={value}"));
     }
+    for allow_url in &shared.allow_urls {
+        args.push(format!("--allow-url {}", allow_url.cli_value()));
+    }
     args
 }
 
@@ -402,6 +417,7 @@ async fn browser_test(
             debugger_options,
         )?;
 
+        let allow_urls = build_allow_list(&origin, &shared_options.allow_urls);
         let mut strategy = TestStrategy {
             rng: AntithesisRng,
             mode,
@@ -415,6 +431,7 @@ async fn browser_test(
             output_path: strategy_output_path,
             violations_count: 0,
             origin,
+            allow_urls,
         };
 
         runner.run(&mut strategy)


### PR DESCRIPTION
### Problem

Bombadil uses the starting URL as an exploration boundary. By default, only the exact origin host is in-bounds — a redirect from `https://example.com` to `https://app.example.com` is treated as off-origin.

Off-origin pages only allow the `Back` action. If the specification offers other actions during that state (e.g. `Wait` while the app bootstraps), the action tree can become empty and the test fails with `no actions available` — even though the redirect is expected and in-scope for the application.

### Solution

Add repeatable `--allow-url <URL_OR_DOMAIN>` to widen the exploration boundary. The origin host is always allowed.

- Domain entries (e.g. `.example.com`) allow that host and its subdomains
- URL entries (e.g. `https://example.com/my/feature`) allow prefix-matched paths on that host
- Port matching reuses the origin URL's port constraint

Replaces the `--origin-domain` approach from the earlier draft, per discussion below.

### Usage

```bash
# Subdomain redirect during bootstrap
bombadil browser test https://example.com spec.ts \
  --allow-url .example.com \
  --time-limit 60s

# Scoped to a path prefix
bombadil browser test https://example.com/app spec.ts \
  --allow-url https://example.com/app \
  --time-limit 60s
```

### Tests

- Unit tests for `AllowUrl` parsing and matching (domain, subdomain, path prefix)
- Integration test: `localhost` → `app.localhost` with `--allow-url localhost`
- Integration test: without the flag, subdomain `Wait` fails with `no actions available`