### PR TITLE
Fix deep violation trees breaking render and Inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Major updates:
 
 * Add `--cookie NAME=VALUE` option to set real browser cookies before testing, scoped to the origin (useful for client-side auth flows that read cookies, unlike `--header`)
 
+Bug fixes:
+
+* Fix stack overflow when rendering violation messages with deeply nested `And` trees
+* Fix Inspect failing to load traces when violation JSON exceeds serde's recursion limit
+
 ## 0.6.1
 
 # Major updates:

--- a/lib/bombadil-cli/src/inspect_server.rs
+++ b/lib/bombadil-cli/src/inspect_server.rs
@@ -10,7 +10,6 @@ use axum::{
 use bombadil_schema::browser::BrowserTraceEntry;
 use include_dir::{Dir, include_dir};
 
-
 static INSPECT_ASSETS: Dir =
     include_dir!("$CARGO_MANIFEST_DIR/../../target/inspect");
 
@@ -66,7 +65,8 @@ async fn trace_handler(
             })?;
 
     let mut entries = Vec::new();
-    for (index, line) in content.lines().filter(|line| !line.is_empty()).enumerate()
+    for (index, line) in
+        content.lines().filter(|line| !line.is_empty()).enumerate()
     {
         let mut entry = match parse_trace_entry(line) {
             Ok(entry) => entry,
@@ -98,7 +98,9 @@ async fn trace_handler(
     Ok(Json(entries))
 }
 
-fn parse_trace_entry(line: &str) -> Result<BrowserTraceEntry, serde_json::Error> {
+fn parse_trace_entry(
+    line: &str,
+) -> Result<BrowserTraceEntry, serde_json::Error> {
     serde_json::from_str(line)
 }
 

--- a/lib/bombadil-cli/src/inspect_server.rs
+++ b/lib/bombadil-cli/src/inspect_server.rs
@@ -10,6 +10,7 @@ use axum::{
 use bombadil_schema::browser::BrowserTraceEntry;
 use include_dir::{Dir, include_dir};
 
+
 static INSPECT_ASSETS: Dir =
     include_dir!("$CARGO_MANIFEST_DIR/../../target/inspect");
 
@@ -64,29 +65,56 @@ async fn trace_handler(
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR
             })?;
 
-    let entries: Vec<BrowserTraceEntry> = content
-        .lines()
-        .filter(|line| !line.is_empty())
-        .map(
-            |line| -> Result<BrowserTraceEntry, axum::http::StatusCode> {
-                let mut entry: BrowserTraceEntry = serde_json::from_str(line)
-                    .map_err(|error| {
-                    log::error!("Failed to parse trace entry: {}", error);
+    let mut entries = Vec::new();
+    for (index, line) in content.lines().filter(|line| !line.is_empty()).enumerate()
+    {
+        let mut entry = match parse_trace_entry(line) {
+            Ok(entry) => entry,
+            Err(error) => {
+                log::warn!(
+                    "Trace entry {} failed to parse ({}). Loading without violations.",
+                    index,
+                    error
+                );
+                parse_trace_entry_without_violations(line).map_err(|error| {
+                    log::error!(
+                        "Failed to parse trace entry {} even without violations: {}",
+                        index,
+                        error
+                    );
                     axum::http::StatusCode::INTERNAL_SERVER_ERROR
-                })?;
-                let filename = std::path::Path::new(&entry.state.screenshot)
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or("")
-                    .to_string();
-                entry.state.screenshot =
-                    format!("/api/screenshots/{}", filename);
-                Ok(entry)
-            },
-        )
-        .collect::<Result<Vec<_>, _>>()?;
+                })?
+            }
+        };
+        let filename = std::path::Path::new(&entry.state.screenshot)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("")
+            .to_string();
+        entry.state.screenshot = format!("/api/screenshots/{}", filename);
+        entries.push(entry);
+    }
 
     Ok(Json(entries))
+}
+
+fn parse_trace_entry(line: &str) -> Result<BrowserTraceEntry, serde_json::Error> {
+    serde_json::from_str(line)
+}
+
+fn parse_trace_entry_without_violations(
+    line: &str,
+) -> Result<BrowserTraceEntry, serde_json::Error> {
+    serde_json::from_str(&strip_violations_field(line))
+}
+
+fn strip_violations_field(line: &str) -> String {
+    let Some(index) = line.rfind(",\"violations\":") else {
+        return line.to_string();
+    };
+    let mut stripped = line[..index].to_string();
+    stripped.push('}');
+    stripped
 }
 
 async fn screenshot_handler(

--- a/lib/bombadil-ltl/tests/fixtures/deep-violation-tree-sample.json
+++ b/lib/bombadil-ltl/tests/fixtures/deep-violation-tree-sample.json
@@ -1,0 +1,91 @@
+done 1790
+ry": {
+    "property": "loadingEventuallyClears",
+    "spec_formula": "always(() => now(() => isLoading.current).implies(eventually(() => !isLoading.current).within(20, \"seconds\")))",
+    "trace_states": 210,
+    "states_with_violations": 37,
+    "max_and_depth": 219,
+    "deepest_violation_trace_line": 210,
+    "node_counts_at_max_depth": {
+      "Always": 217,
+      "And": 194,
+      "Implies": 195,
+      "Eventually": 195
+    },
+    "raw_violation_json_bytes": 129666
+  },
+  "violation_truncated": {
+    "Always": {
+      "start": "<timestamp>",
+      "time": "<timestamp>",
+      "subformula": "() => now(() => isLoading.current).implies(eventually(() => !isLoading.current).within(20, \"seconds\"))",
+      "violation": {
+        "And": {
+          "left": {
+            "Always": {
+              "start": "<timestamp>",
+              "time": "<timestamp>",
+              "subformula": "() => now(() => isLoading.current).implies(eventually(() => !isLoading.current).within(20, \"seconds\"))",
+              "violation": {
+                "Implies": {
+                  "left": "() => isLoading.current",
+                  "right": {
+                    "Eventually": {
+                      "subformula": "() => !isLoading.current",
+                      "reason": "TimedOut"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "right": {
+            "And": {
+              "left": {
+                "Always": {
+                  "start": "<timestamp>",
+                  "time": "<timestamp>",
+                  "subformula": "() => now(() => isLoading.current).implies(eventually(() => !isLoading.current).within(20, \"seconds\"))",
+                  "violation": {
+                    "Implies": {
+                      "left": "() => isLoading.current",
+                      "right": {
+                        "Eventually": {
+                          "subformula": "() => !isLoading.current",
+                          "reason": "TimedOut"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "right": {
+                "And": {
+                  "left": {
+                    "Always": {
+                      "start": "<timestamp>",
+                      "time": "<timestamp>",
+                      "subformula": "() => now(() => isLoading.current).implies(eventually(() => !isLoading.current).within(20, \"seconds\"))",
+                      "violation": {
+                        "Implies": {
+                          "left": "() => isLoading.current",
+                          "right": {
+                            "Eventually": {
+                              "subformula": "() => !isLoading.current",
+                              "reason": "TimedOut"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "right": "<truncated: more And nodes at each prior timestep>"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/bombadil-schema/src/markup.rs
+++ b/lib/bombadil-schema/src/markup.rs
@@ -145,29 +145,23 @@ fn render_violation_inner(violation: &Violation, current_time: Time) -> Markup {
             render_violation_inner(violation, *time),
         ]),
         Violation::And { .. } => {
-            let leaves = flatten_binary_violations(
-                violation,
-                |node| {
-                    if let Violation::And { left, right } = node {
-                        Some((left.as_ref(), right.as_ref()))
-                    } else {
-                        None
-                    }
-                },
-            );
+            let leaves = flatten_binary_violations(violation, |node| {
+                if let Violation::And { left, right } = node {
+                    Some((left.as_ref(), right.as_ref()))
+                } else {
+                    None
+                }
+            });
             render_violation_list(&leaves, current_time, "and")
         }
         Violation::Or { .. } => {
-            let leaves = flatten_binary_violations(
-                violation,
-                |node| {
-                    if let Violation::Or { left, right } = node {
-                        Some((left.as_ref(), right.as_ref()))
-                    } else {
-                        None
-                    }
-                },
-            );
+            let leaves = flatten_binary_violations(violation, |node| {
+                if let Violation::Or { left, right } = node {
+                    Some((left.as_ref(), right.as_ref()))
+                } else {
+                    None
+                }
+            });
             render_violation_list(&leaves, current_time, "and")
         }
         Violation::Implies {
@@ -205,9 +199,7 @@ fn render_violation_list(
     let mut parts = Vec::with_capacity(violations.len() * 2 - 1);
     for (index, violation) in violations.iter().enumerate() {
         if index > 0 {
-            parts.push(Markup::Span(vec![Inline::Keyword(
-                separator.into(),
-            )]));
+            parts.push(Markup::Span(vec![Inline::Keyword(separator.into())]));
         }
         parts.push(render_violation_inner(violation, current_time));
     }
@@ -372,7 +364,9 @@ mod tests {
     use std::time::{Duration, SystemTime};
 
     fn time(ms: u64) -> Time {
-        Time::from_system_time(SystemTime::UNIX_EPOCH + Duration::from_millis(ms))
+        Time::from_system_time(
+            SystemTime::UNIX_EPOCH + Duration::from_millis(ms),
+        )
     }
 
     fn eventually_violation() -> Violation {

--- a/lib/bombadil-schema/src/markup.rs
+++ b/lib/bombadil-schema/src/markup.rs
@@ -76,7 +76,6 @@ fn flatten_binary_violations<'a>(
         }
     }
 
-    leaves.reverse();
     leaves
 }
 
@@ -360,7 +359,9 @@ fn render_formula(formula: &Formula) -> Markup {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::schema::{EventuallyViolation, Formula, PropertyViolation};
+    use crate::schema::{
+        EventuallyViolation, Formula, PropertyViolation, Violation,
+    };
     use std::time::{Duration, SystemTime};
 
     fn time(ms: u64) -> Time {
@@ -377,6 +378,63 @@ mod tests {
             }),
             reason: EventuallyViolation::TimedOut(time(1)),
         }
+    }
+
+    fn false_violation(condition: &str) -> Violation {
+        Violation::False {
+            time: time(0),
+            condition: condition.into(),
+            snapshots: vec![],
+        }
+    }
+
+    fn inline_codes(markup: &Markup) -> Vec<String> {
+        let mut codes = Vec::new();
+        collect_inline_codes(markup, &mut codes);
+        codes
+    }
+
+    fn collect_inline_codes(markup: &Markup, codes: &mut Vec<String>) {
+        match markup {
+            Markup::Span(inlines) => {
+                for inline in inlines {
+                    if let Inline::Code(code) = inline {
+                        codes.push(code.clone());
+                    }
+                }
+            }
+            Markup::Join(parts) | Markup::Stack(parts) => {
+                for part in parts {
+                    collect_inline_codes(part, codes);
+                }
+            }
+            Markup::Snapshots(_) | Markup::CodeBlock(_) | Markup::Comma => {}
+        }
+    }
+
+    #[test]
+    fn flatten_binary_violations_preserves_left_to_right_order() {
+        let violation = Violation::Or {
+            left: Box::new(false_violation("first")),
+            right: Box::new(Violation::Or {
+                left: Box::new(false_violation("second")),
+                right: Box::new(false_violation("third")),
+            }),
+        };
+
+        let rendered = render_violation(&PropertyViolation {
+            name: "test".into(),
+            violation,
+        });
+
+        assert_eq!(
+            inline_codes(&rendered),
+            vec![
+                "!(first)".into(),
+                "!(second)".into(),
+                "!(third)".into(),
+            ]
+        );
     }
 
     #[test]

--- a/lib/bombadil-schema/src/markup.rs
+++ b/lib/bombadil-schema/src/markup.rs
@@ -60,6 +60,26 @@ fn get_violation_time(violation: &Violation) -> Time {
     }
 }
 
+fn flatten_binary_violations<'a>(
+    violation: &'a Violation,
+    split: fn(&'a Violation) -> Option<(&'a Violation, &'a Violation)>,
+) -> Vec<&'a Violation> {
+    let mut stack = vec![violation];
+    let mut leaves = Vec::new();
+
+    while let Some(node) = stack.pop() {
+        if let Some((left, right)) = split(node) {
+            stack.push(right);
+            stack.push(left);
+        } else {
+            leaves.push(node);
+        }
+    }
+
+    leaves.reverse();
+    leaves
+}
+
 fn render_violation_inner(violation: &Violation, current_time: Time) -> Markup {
     match violation {
         Violation::False {
@@ -124,16 +144,32 @@ fn render_violation_inner(violation: &Violation, current_time: Time) -> Markup {
             Markup::Span(vec![Inline::Text("however".into())]),
             render_violation_inner(violation, *time),
         ]),
-        Violation::And { left, right } => Markup::Join(vec![
-            render_violation_inner(left, current_time),
-            Markup::Span(vec![Inline::Keyword("and".into())]),
-            render_violation_inner(right, current_time),
-        ]),
-        Violation::Or { left, right } => Markup::Join(vec![
-            render_violation_inner(left, current_time),
-            Markup::Span(vec![Inline::Keyword("and".into())]),
-            render_violation_inner(right, current_time),
-        ]),
+        Violation::And { .. } => {
+            let leaves = flatten_binary_violations(
+                violation,
+                |node| {
+                    if let Violation::And { left, right } = node {
+                        Some((left.as_ref(), right.as_ref()))
+                    } else {
+                        None
+                    }
+                },
+            );
+            render_violation_list(&leaves, current_time, "and")
+        }
+        Violation::Or { .. } => {
+            let leaves = flatten_binary_violations(
+                violation,
+                |node| {
+                    if let Violation::Or { left, right } = node {
+                        Some((left.as_ref(), right.as_ref()))
+                    } else {
+                        None
+                    }
+                },
+            );
+            render_violation_list(&leaves, current_time, "and")
+        }
         Violation::Implies {
             left,
             right,
@@ -159,6 +195,23 @@ fn render_violation_inner(violation: &Violation, current_time: Time) -> Markup {
             }
         }
     }
+}
+
+fn render_violation_list(
+    violations: &[&Violation],
+    current_time: Time,
+    separator: &str,
+) -> Markup {
+    let mut parts = Vec::with_capacity(violations.len() * 2 - 1);
+    for (index, violation) in violations.iter().enumerate() {
+        if index > 0 {
+            parts.push(Markup::Span(vec![Inline::Keyword(
+                separator.into(),
+            )]));
+        }
+        parts.push(render_violation_inner(violation, current_time));
+    }
+    Markup::Join(parts)
 }
 
 fn render_code(code: String) -> Markup {
@@ -309,5 +362,44 @@ fn render_formula(formula: &Formula) -> Markup {
             Markup::Span(vec![Inline::Text(format_bound(*bound))]),
             render_formula(formula),
         ]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{EventuallyViolation, Formula, PropertyViolation};
+    use std::time::{Duration, SystemTime};
+
+    fn time(ms: u64) -> Time {
+        Time::from_system_time(SystemTime::UNIX_EPOCH + Duration::from_millis(ms))
+    }
+
+    fn eventually_violation() -> Violation {
+        Violation::Eventually {
+            subformula: Box::new(Formula::Thunk {
+                function: "() => false".into(),
+                negated: false,
+            }),
+            reason: EventuallyViolation::TimedOut(time(1)),
+        }
+    }
+
+    #[test]
+    fn deep_and_chain_renders_without_stack_overflow() {
+        let mut violation = eventually_violation();
+        for _ in 0..500 {
+            violation = Violation::And {
+                left: Box::new(violation),
+                right: Box::new(eventually_violation()),
+            };
+        }
+
+        let rendered = render_violation(&PropertyViolation {
+            name: "test".into(),
+            violation,
+        });
+
+        assert!(matches!(rendered, Markup::Join(_)));
     }
 }

--- a/lib/bombadil-schema/src/markup.rs
+++ b/lib/bombadil-schema/src/markup.rs
@@ -429,11 +429,7 @@ mod tests {
 
         assert_eq!(
             inline_codes(&rendered),
-            vec![
-                "!(first)".into(),
-                "!(second)".into(),
-                "!(third)".into(),
-            ]
+            vec!["!(first)".into(), "!(second)".into(), "!(third)".into(),]
         );
     }
 

--- a/lib/bombadil-schema/src/markup.rs
+++ b/lib/bombadil-schema/src/markup.rs
@@ -427,10 +427,11 @@ mod tests {
             violation,
         });
 
-        assert_eq!(
-            inline_codes(&rendered),
-            vec!["!(first)".into(), "!(second)".into(), "!(third)".into(),]
-        );
+        let expected: Vec<String> = ["!(first)", "!(second)", "!(third)"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        assert_eq!(inline_codes(&rendered), expected);
     }
 
     #[test]


### PR DESCRIPTION
### Problem

When an LTL property stays violated across many timesteps, the evaluator can produce violation trees with deeply nested `And` nodes (194+ in a real trace). That bloated JSON then breaks downstream handling:

1. **CLI** — `render_violation_inner` recurses through the `And` chain and the tokio worker stack overflows while printing violations.
2. **Inspect** — serde's default recursion limit (128) rejects the JSON when loading `trace.jsonl`, so `/api/trace` returns 500.

See [review comment](https://github.com/antithesishq/bombadil/pull/243#issuecomment-4847436619) for trace analysis. The repeating `Always` / `Implies` / `Eventually(TimedOut)` pattern suggests the root cause is in the evaluator, not rendering.

### Current changes (workarounds)

- Flatten `And`/`Or` iteratively when rendering violation messages.
- Strip `violations` on Inspect parse failure so the rest of the trace remains viewable.
- Fixture: `lib/bombadil-ltl/tests/fixtures/deep-violation-tree-sample.json`

### Tests

- `deep_and_chain_renders_without_stack_overflow` (500-deep `And` chain)
- `flatten_binary_violations_preserves_left_to_right_order`

Happy to close this and focus on an evaluator fix instead.