### PR TITLE
Use `--headless=new` explicitly for managed browser launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,7 @@
 Major updates:
 
 * Add `--cookie NAME=VALUE` option to set real browser cookies before testing, scoped to the origin (useful for client-side auth flows that read cookies, unlike `--header`)
-
-Bug fixes:
-
-* Use Chrome's `--headless=new` mode when `--headless` is set, so modern Chromium does not fall back to a visible window
+* Pass `--headless=new` when launching a managed browser with `--headless`, instead of chromiumoxide's default `--headless` flag
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Major updates:
 
 * Add `--cookie NAME=VALUE` option to set real browser cookies before testing, scoped to the origin (useful for client-side auth flows that read cookies, unlike `--header`)
 
+Bug fixes:
+
+* Use Chrome's `--headless=new` mode when `--headless` is set, so modern Chromium does not fall back to a visible window
+
 ## 0.6.1
 
 # Major updates:

--- a/lib/bombadil-browser/src/browser.rs
+++ b/lib/bombadil-browser/src/browser.rs
@@ -1348,7 +1348,9 @@ fn launch_options_to_config(
     let apply_headless =
         |builder: BrowserConfigBuilder| -> BrowserConfigBuilder {
             if launch_options.headless {
-                builder
+                // Chrome 120+ removed legacy `--headless`; use `--headless=new`
+                // so `--headless` CLI flag stays invisible on modern Chromium.
+                builder.new_headless_mode()
             } else {
                 builder.with_head()
             }

--- a/lib/bombadil-browser/src/browser.rs
+++ b/lib/bombadil-browser/src/browser.rs
@@ -1348,8 +1348,6 @@ fn launch_options_to_config(
     let apply_headless =
         |builder: BrowserConfigBuilder| -> BrowserConfigBuilder {
             if launch_options.headless {
-                // Chrome 120+ removed legacy `--headless`; use `--headless=new`
-                // so `--headless` CLI flag stays invisible on modern Chromium.
                 builder.new_headless_mode()
             } else {
                 builder.with_head()


### PR DESCRIPTION
### Problem

When `LaunchOptions.headless` is true, Bombadil leaves chromiumoxide at its default headless setting (`HeadlessMode::True`), which passes bare `--headless`.

That works on current Chrome (132+ treats `--headless` and `--headless=new` as new headless per [Chrome's headless migration notes](https://developer.chrome.com/blog/removing-headless-old-from-chrome)), but the intent is implicit and depends on chromiumoxide's default mapping.

### Solution

When `LaunchOptions.headless` is true, call `BrowserConfigBuilder::new_headless_mode()` so Chromium is launched with `--headless=new`.

Headed runs are unchanged (`with_head()`).

### Testing

- `cargo test -p bombadil-browser-integration-tests test_other_domain`