### PR TITLE
nix: stop manually passing target/rustflags

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,6 @@
         };
         bombadil = pkgs.callPackage ./lib/nix/default.nix {
           inherit craneLib craneLibStatic ghosttySrc;
-          cargoTarget = muslTarget;
         };
       in
       {

--- a/lib/nix/default.nix
+++ b/lib/nix/default.nix
@@ -105,7 +105,7 @@ let
         filter = path: type: craneLib.filterCargoSources path type;
       };
     in
-    runCommand "bombadil-deps-src" { } ''
+    runCommand "source" { } ''
       cp -r ${cargoOnly} $out
       chmod -R +w $out
       sed -i '0,/^version = /{s/^version = .*/version = "0.0.0"/}' $out/Cargo.toml

--- a/lib/nix/default.nix
+++ b/lib/nix/default.nix
@@ -15,7 +15,6 @@
   libiconv ? null,
   craneLib,
   craneLibStatic,
-  cargoTarget ? "x86_64-unknown-linux-musl",
   darwin ? null,
   xcbuild ? null,
   # Ghostty source pinned to the commit referenced by libghostty-vt-sys's
@@ -197,8 +196,6 @@ in
     }
     // lib.optionalAttrs stdenv.isLinux {
       cargoArtifacts = cargoArtifactsStatic;
-      CARGO_BUILD_TARGET = cargoTarget;
-      CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
     }
     // lib.optionalAttrs stdenv.isDarwin {
       # Rewrite Nix store dylib references to system paths so the binary


### PR DESCRIPTION
Doing this makes it so that we can't reuse dependencies, so we end up rebuilding them unconditionally. It appears this was a Claude-ism that does not actually affect anything. :(