### PR TITLE
fix: drop dangling ./random export from npm package

### DIFF
--- a/lib/nix/npm-package.nix
+++ b/lib/nix/npm-package.nix
@@ -36,9 +36,6 @@ let
         "./terminal" = {
           types = "./dist/terminal/index.d.ts";
         };
-        "./random" = {
-          types = "./dist/random.d.ts";
-        };
         "./actions" = {
           types = "./dist/actions.d.ts";
         };


### PR DESCRIPTION
Fixes #253.

## What's actually broken on `main`

The bug as reported in #253 — `dist/actions.d.ts` re-exporting a `randomRange` that `dist/random.d.ts` doesn't declare — no longer reproduces on `main`. `random.ts` was deleted wholesale in #233, after `v0.6.1` shipped.

What survived that deletion is the `./random` entry in the generated `package.json`, which still points at `./dist/random.d.ts`. The build no longer emits that file, so any consumer importing the subpath gets:

```
error TS2307: Cannot find module '@antithesishq/bombadil/random' or its corresponding type declarations.
```

Same root cause as the reported TS2305, same fix: the export map hadn't caught up with the removal.

## The change

Delete the three dead lines from `lib/nix/npm-package.nix`.

## How this shipped

Both failure modes are invisible to the build. `lib/bombadil/src/specification/tsconfig.json` sets `skipLibCheck: true`, so `tsc` never checks the library's own declarations, and CI's `test-npm-package` job only runs `npx bombadil --version` against the tarball — it never type-checks anything. On `v0.6.1` the `randomRange` re-export additionally depended on `--stripInternal` removing a `/** @internal */` symbol that a *different* module re-exported publicly, which no single-file review would catch.

## Verification

I built the declarations with the same `tsc` invocation the Nix derivation uses, at both refs.

At `v0.6.1`, reproducing the issue exactly:

```
dist/actions.d.ts(3,53): error TS2305: Module '"@antithesishq/bombadil/random"' has no exported member 'randomRange'.
```

At `main` with this change, a spec importing every remaining subpath plus the README example type-checks clean with `skipLibCheck: false` under all three supported resolution modes:

| `moduleResolution` | result |
| --- | --- |
| `bundler` | pass |
| `node16` | pass |
| `nodenext` | pass |

(`node10` cannot follow `exports` at all and is unaffected either way.)

## Deliberately out of scope

Two adjacent problems I hit while verifying, both worth separate issues:

1. `dist/terminal/defaults.d.ts`, `terminal/defaults/actions.d.ts`, and `terminal/defaults/properties.d.ts` are emitted but absent from the export map, so the terminal counterpart of the README's `export * from "@antithesishq/bombadil/browser/defaults"` doesn't resolve. The browser equivalents are all exported.
2. `bundler/fixtures/**` gets declaration-emitted into `dist` and published — nine fixture `.d.ts` files that aren't API.

Neither is a regression from this issue, and a guard in CI that type-checks the tarball would catch this whole class, but that's a bigger change than this fix warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
