### PR TITLE
fix: pass generation through with action to discard stale ones

### DIFF
--- a/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
+++ b/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
@@ -8,8 +8,8 @@ use axum::{
 };
 use bombadil_schema::{Time, markup};
 use rand::SeedableRng;
-use std::collections::HashMap;
 use std::io::Write;
+use std::{collections::HashMap, sync::Arc};
 use std::{
     fmt::Display,
     sync::Once,
@@ -530,16 +530,19 @@ async fn test_browser_lifecycle() {
 
     browser.initiate().await.unwrap();
 
-    match browser.next_event().await.unwrap() {
+    let state = match browser.next_event().await.unwrap() {
         bombadil_browser::browser::BrowserEvent::StateChanged(state) => {
             assert_eq!(state.title, "Console Error");
+            state
         }
         bombadil_browser::browser::BrowserEvent::Error(error) => {
             panic!("unexpected browser error: {}", error)
         }
-    }
+    };
 
-    browser.apply(BrowserAction::Reload).unwrap();
+    browser
+        .apply(BrowserAction::Reload, Arc::new(state))
+        .unwrap();
 
     match browser.next_event().await.unwrap() {
         bombadil_browser::browser::BrowserEvent::StateChanged(state) => {

--- a/lib/bombadil-browser/src/browser.rs
+++ b/lib/bombadil-browser/src/browser.rs
@@ -1,3 +1,4 @@
+use anyhow::ensure;
 use anyhow::{Context, Result, anyhow, bail};
 use chromiumoxide::browser::BrowserConfigBuilder;
 use chromiumoxide::cdp::browser_protocol::browser;
@@ -28,6 +29,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use url::Url;
 
 use crate::browser::actions::{ActionOptions, BrowserAction};
+use crate::browser::state::Generation;
 use crate::browser::state::{
     BrowserState, CallFrame, ConsoleEntry, Exception, Screenshot,
     ScreenshotFormat,
@@ -113,7 +115,7 @@ enum InnerEvent {
     },
     TargetDestroyed(TargetId),
     ConsoleEntry(ConsoleEntry),
-    ActionAccepted(BrowserAction),
+    ActionAccepted(BrowserAction, Generation),
     ActionApplied(Generation),
     ExceptionThrown(Exception),
     Quiesced(Generation),
@@ -126,21 +128,6 @@ enum StateRequestReason {
     Quiesced,
 }
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-struct Generation(u64);
-
-impl Generation {
-    fn next(self) -> Self {
-        Generation(self.0 + 1)
-    }
-}
-
-impl std::fmt::Display for Generation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 /// Initial idle timeout before the first activity signal arrives.
 /// Deliberately long so we don't fire before the browser has produced
 /// any frames; the first activity event will replace this with a much shorter
@@ -151,7 +138,7 @@ const NAVIGATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 struct BrowserContext {
     sender: Sender<BrowserEvent>,
-    actions_sender: Sender<BrowserAction>,
+    actions_sender: Sender<(BrowserAction, Generation)>,
     inner_events_sender: Sender<InnerEvent>,
     shutdown_receiver: oneshot::Receiver<()>,
     page: Arc<Page>,
@@ -198,7 +185,7 @@ pub enum DebuggerOptions {
 pub struct Browser {
     receiver: Receiver<BrowserEvent>,
     inner_events_sender: Sender<InnerEvent>,
-    actions_sender: Sender<BrowserAction>,
+    actions_sender: Sender<(BrowserAction, Generation)>,
     shutdown_sender: Option<oneshot::Sender<()>>,
     done_receiver: Option<oneshot::Receiver<()>>,
     browser: Option<chromiumoxide::Browser>,
@@ -250,7 +237,7 @@ impl Browser {
 
         let (sender, receiver) = channel::<BrowserEvent>(1);
 
-        let (actions_sender, _) = channel::<BrowserAction>(1);
+        let (actions_sender, _) = channel::<(BrowserAction, Generation)>(1);
 
         let page = if browser_options.create_target {
             Arc::new(browser.new_page("about:blank").await.context(
@@ -493,8 +480,12 @@ impl Browser {
         }
     }
 
-    pub fn apply(&mut self, action: BrowserAction) -> Result<()> {
-        self.actions_sender.send(action)?;
+    pub fn apply(
+        &mut self,
+        action: BrowserAction,
+        state: Arc<BrowserState>,
+    ) -> Result<()> {
+        self.actions_sender.send((action, state.generation))?;
         Ok(())
     }
 
@@ -734,10 +725,12 @@ async fn inner_events(
             }),
     ) as InnerEventStream;
 
-    let events_action_accepted = Box::pin(
-        receiver_to_stream(context.actions_sender.subscribe())
-            .map(InnerEvent::ActionAccepted),
-    );
+    let events_action_accepted =
+        Box::pin(receiver_to_stream(context.actions_sender.subscribe()).map(
+            |(action, generation)| {
+                InnerEvent::ActionAccepted(action, generation)
+            },
+        ));
 
     Ok(Box::pin(stream::select_all(vec![
         events_loaded,
@@ -887,6 +880,7 @@ async fn process_event(
                 screenshot,
                 ..
             } = state.shared;
+            let generation = generation.next();
 
             let screenshot = screenshot
                 .ok_or(anyhow!("no screenshot available for state capture"))?;
@@ -897,14 +891,13 @@ async fn process_event(
                 console_entries,
                 exceptions,
                 screenshot,
+                generation,
             )
             .await?;
 
             context
                 .sender
                 .send(BrowserEvent::StateChanged(browser_state))?;
-
-            let generation = generation.next();
 
             InnerState {
                 kind: Paused,
@@ -921,8 +914,12 @@ async fn process_event(
                 kind: Paused,
                 shared,
             },
-            InnerEvent::ActionAccepted(browser_action),
+            InnerEvent::ActionAccepted(browser_action, generation),
         ) => {
+            ensure!(
+                shared.generation == generation,
+                "cannot accept action from stale generation {generation}"
+            );
             context
                 .page
                 .execute(debugger::ResumeParams::builder().build())
@@ -933,18 +930,17 @@ async fn process_event(
             }
         }
         (
-            state @ InnerState {
-                kind: Loading | Navigating { .. } | Pausing,
-                ..
-            },
-            InnerEvent::ActionAccepted(action),
-        ) => {
-            log::debug!(
-                "ignoring action {:?} received during {:?}",
+            InnerState { kind, shared },
+            InnerEvent::ActionAccepted(action, generation),
+        ) if shared.generation >= generation => {
+            log::warn!(
+                "ignoring stale action {:?}({}) received during {:?}({})",
                 action,
-                state.kind
+                generation,
+                kind,
+                shared.generation
             );
-            state
+            InnerState { kind, shared }
         }
         (
             InnerState {
@@ -1135,21 +1131,22 @@ async fn process_event(
         }
         (state, InnerEvent::FrameNavigated(frame_id, navigation_type)) => {
             if frame_id == context.frame_id {
+                let shared = InnerStateShared {
+                    generation: state.shared.generation.next(),
+                    ..state.shared
+                };
                 let kind = match navigation_type {
                     NavigationType::Navigation => Loading,
                     NavigationType::BackForwardCacheRestore => {
                         let timer = start_quiescence_timer(
-                            &state.shared,
+                            &shared,
                             context,
                             &context.inner_events_sender,
                         );
                         Running(timer)
                     }
                 };
-                InnerState {
-                    kind,
-                    shared: state.shared,
-                }
+                InnerState { kind, shared }
             } else {
                 state
             }

--- a/lib/bombadil-browser/src/browser/state.rs
+++ b/lib/bombadil-browser/src/browser/state.rs
@@ -21,11 +21,27 @@ use crate::browser::evaluation::{
     evaluate_expression_in_debugger, evaluate_function_call_in_debugger,
 };
 
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Generation(u64);
+
+impl Generation {
+    pub fn next(self) -> Self {
+        Generation(self.0 + 1)
+    }
+}
+
+impl std::fmt::Display for Generation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct BrowserState {
     page: Arc<Page>,
     call_frame_id: CallFrameId,
 
+    pub generation: Generation,
     pub timestamp: SystemTime,
     pub url: Url,
     pub title: String,
@@ -197,6 +213,7 @@ impl BrowserState {
         console_entries: Vec<ConsoleEntry>,
         exceptions: Vec<Exception>,
         screenshot: Screenshot,
+        generation: Generation,
     ) -> Result<Self> {
         log::trace!("BrowserState::current: evaluating url");
         let url = Url::parse(
@@ -366,6 +383,7 @@ impl BrowserState {
 
         log::trace!("BrowserState::current: done");
         Ok(BrowserState {
+            generation,
             timestamp: SystemTime::now(),
             page: page.clone(),
             call_frame_id: call_frame_id.clone(),

--- a/lib/bombadil-browser/src/driver.rs
+++ b/lib/bombadil-browser/src/driver.rs
@@ -31,6 +31,7 @@ enum BrowserCommand {
     },
     Apply {
         action: BrowserAction,
+        state: Arc<BrowserState>,
         reply: std_mpsc::Sender<Result<()>>,
     },
     ExtractSnapshots {
@@ -157,11 +158,16 @@ impl InterfaceDriver for BrowserDriver {
         }
     }
 
-    fn apply(&mut self, action: BrowserAction) -> Result<()> {
+    fn apply(
+        &mut self,
+        action: BrowserAction,
+        state: Arc<BrowserState>,
+    ) -> Result<()> {
         let (reply_send, reply_receive) = std_mpsc::channel();
         self.command_send
             .send(BrowserCommand::Apply {
                 action,
+                state,
                 reply: reply_send,
             })
             .map_err(|_| anyhow!("browser worker gone"))?;
@@ -246,7 +252,7 @@ fn run_browser_worker(
                 BrowserCommand::NextEvent { reply } => {
                     let event = match browser.next_event().await {
                         Some(BrowserEvent::StateChanged(state)) => {
-                            Some(DriverEvent::StateChanged(state))
+                            Some(DriverEvent::StateChanged(Arc::new(state)))
                         }
                         Some(BrowserEvent::Error(error)) => {
                             Some(DriverEvent::Error(error))
@@ -255,8 +261,12 @@ fn run_browser_worker(
                     };
                     let _ = reply.send(event);
                 }
-                BrowserCommand::Apply { action, reply } => {
-                    let _ = reply.send(browser.apply(action));
+                BrowserCommand::Apply {
+                    action,
+                    state,
+                    reply,
+                } => {
+                    let _ = reply.send(browser.apply(action, state));
                 }
                 BrowserCommand::ExtractSnapshots {
                     state,

--- a/lib/bombadil-terminal/src/driver.rs
+++ b/lib/bombadil-terminal/src/driver.rs
@@ -340,13 +340,17 @@ impl InterfaceDriver for TerminalDriver {
     fn next_event(&mut self) -> Option<DriverEvent<TerminalState>> {
         self.drain_output(self.quiescence_timeout);
         match self.extract_state() {
-            Ok(state) => Some(DriverEvent::StateChanged(state)),
+            Ok(state) => Some(DriverEvent::StateChanged(Arc::new(state))),
             Err(error) => Some(DriverEvent::Error(Arc::new(error))),
         }
     }
 
     #[hotpath::measure]
-    fn apply(&mut self, action: TerminalAction) -> Result<()> {
+    fn apply(
+        &mut self,
+        action: TerminalAction,
+        _: Arc<TerminalState>,
+    ) -> Result<()> {
         match &action {
             TerminalAction::TypeText { text } => {
                 self.process.borrow_mut().write(text.as_bytes());

--- a/lib/bombadil/src/driver.rs
+++ b/lib/bombadil/src/driver.rs
@@ -37,7 +37,11 @@ pub trait InterfaceDriver {
 
     fn next_event(&mut self) -> Option<DriverEvent<Self::State>>;
 
-    fn apply(&mut self, action: Self::Action) -> Result<()>;
+    fn apply(
+        &mut self,
+        action: Self::Action,
+        state: Arc<Self::State>,
+    ) -> Result<()>;
 
     fn extract_snapshots(
         &mut self,
@@ -50,6 +54,6 @@ pub trait InterfaceDriver {
 
 #[derive(Debug, Clone)]
 pub enum DriverEvent<S> {
-    StateChanged(S),
+    StateChanged(Arc<S>),
     Error(Arc<anyhow::Error>),
 }

--- a/lib/bombadil/src/runner.rs
+++ b/lib/bombadil/src/runner.rs
@@ -94,7 +94,6 @@ impl<D: InterfaceDriver> Runner<D> {
             let event = driver.next_event();
             match event {
                 Some(DriverEvent::StateChanged(state)) => {
-                    let state = Arc::new(state);
                     let snapshots: Arc<[Snapshot]> = driver
                         .extract_snapshots(state.clone(), last_action.as_ref())?
                         .into();
@@ -163,7 +162,7 @@ impl<D: InterfaceDriver> Runner<D> {
                         ControlFlow::Stop(value) => return Ok(value),
                         ControlFlow::Continue(action) => {
                             log::info!("picked action: {:?}", action);
-                            driver.apply(action.clone())?;
+                            driver.apply(action.clone(), state.clone())?;
                             last_action = Some(action);
                         }
                     }


### PR DESCRIPTION
Previously, we discarded `ActionAccepted` only based on state kind, and the union of states in which to discard actions was missing a case for `Running`. When the browser navigated back or forward and hit an exception, that triggered an eager state read, which then raced with the FrameNavigated(BackForwardCacheRestore) event, ending up Running + ActionAccepted.

Bumping generations and threading the generation through the action selection in the runner (in BrowserState) solves this in a robust way.