### PR TITLE
add specific error messages/context for failed trace writes

### DIFF
--- a/lib/bombadil-cli/src/terminal.rs
+++ b/lib/bombadil-cli/src/terminal.rs
@@ -209,6 +209,15 @@ pub fn run(command: Command) {
 
             if let Err(error) = run_test() {
                 eprintln!("\n\nterminal test failed: {error}");
+
+                if let Some(source) = error.source() {
+                    eprintln!("\nCauses:");
+
+                    for cause in anyhow::Chain::new(source) {
+                        eprintln!("  - {cause}");
+                    }
+                }
+
                 exit(1);
             }
         }

--- a/lib/bombadil-terminal/src/trace.rs
+++ b/lib/bombadil-terminal/src/trace.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{BufWriter, Write},
+    io::{self, BufWriter, Write},
     path::PathBuf,
     sync::mpsc,
     thread::JoinHandle,
@@ -214,17 +214,29 @@ fn worker_loop(
                     &entry.violations,
                 )?;
                 buffer.push(b'\n');
-                trace_file.write_all(&buffer)?;
+                trace_file.write_all(&buffer).map_err(trace_write_error)?;
             }
             Message::Flush(ack) => {
-                let result = trace_file.flush().map_err(Into::into);
+                let result = trace_file.flush().map_err(trace_write_error);
                 // The flusher may have given up waiting; ignore that.
                 let _ = ack.send(result);
             }
         }
     }
-    trace_file.flush()?;
+    trace_file.flush().map_err(trace_write_error)?;
     Ok(())
+}
+
+fn trace_write_error(error: io::Error) -> anyhow::Error {
+    let message = match error.kind() {
+        io::ErrorKind::QuotaExceeded => {
+            "try using `--output-path` to write traces outside \
+            of the temporary directory"
+        }
+        _ => "failed to write to trace file",
+    };
+
+    anyhow!(error).context(message)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #252 

- keeps the underlying I/O error in the error chain.
- prints the topmost error, and then any other causes if they exist.
- I wrote custom (but basic) printing logic because the existing options didn't seem as good:
  - alternative display formatting (`{error:#}`) prints all causes on a single line, separated by colons.
  - debug formatting (`{error:?}`) prints a backtrace if one exists. If you're fine with a backtrace being displayed, then this could be used instead of the current implementation; let me know if you'd like me to change it.
- I put the error mapping into a separate function because the same logic is used in a few places.

Here's what the error now looks like for the case I described in the original issue:

```
terminal test failed: try using `--output-path` to write traces outside of the temporary directory

Causes:
  - Disk quota exceeded (os error 122)
```

I have run locally all of the checks mentioned in the contributing docs:

```
cargo build --workspace --exclude bombadil-inspect
cargo clippy --workspace --exclude bombadil-inspect --fix --allow-dirty
cargo fmt --all
cargo test
```

<hr>

Tangentially related: have you looked into the viability of storing the traces as diffs rather than full snapshots at all? That would certainly reduce the size a lot, and would probably be faster to write.

