### PR TITLE
feat(UX/DX Improvement): copy Inspect violation details

### DIFF
--- a/lib/bombadil-inspect/Cargo.toml
+++ b/lib/bombadil-inspect/Cargo.toml
@@ -15,12 +15,14 @@ serde_json.workspace = true
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
 web-sys = { workspace = true, features = [
+    "Clipboard",
     "DomRectReadOnly",
     "Element",
     "Event",
     "EventTarget",
     "HtmlElement",
     "HtmlImageElement",
+    "Navigator",
     "ResizeObserver",
     "ResizeObserverEntry",
     "Window",

--- a/lib/bombadil-inspect/src/state-details.css
+++ b/lib/bombadil-inspect/src/state-details.css
@@ -28,6 +28,48 @@
   text-transform: uppercase;
 }
 
+.state-details .copy-details {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  right: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(var(--line-height) * 1.5);
+  height: calc(var(--line-height) * 1.5);
+  border: 0;
+  border-left: 1px solid currentColor;
+  padding: .5rem;
+  color: currentColor;
+  background: var(--color-bg);
+  font: inherit;
+  cursor: pointer;
+}
+
+.state-details .copy-details:hover {
+  background: var(--color-bg-muted);
+}
+
+.state-details .copy-details:focus:not(:focus-visible) {
+  outline: none;
+  border-radius: 0;
+}
+
+.state-details .copy-details:focus-visible {
+  outline: none;
+  border-radius: 0;
+  box-shadow: inset 0 0 0 2px var(--color-selected);
+}
+
+.state-details .copy-details svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.25;
+}
+
 .state-details table th,
 .state-details table td {
   padding: var(--spacing-vertical) var(--spacing-horizontal);

--- a/lib/bombadil-inspect/src/state_details.rs
+++ b/lib/bombadil-inspect/src/state_details.rs
@@ -1,13 +1,22 @@
 use std::rc::Rc;
 
-use bombadil_schema::Time;
 use bombadil_schema::browser;
+use bombadil_schema::{PropertyViolation, Snapshot, Time};
+use gloo_timers::callback::Timeout;
+use serde::Serialize;
 use serde_json as json;
+use wasm_bindgen_futures::{JsFuture, spawn_local};
 use yew::component;
 use yew::prelude::*;
 
 use crate::container_size::use_container_size;
 use crate::render::{markup_to_html, render_violation};
+
+#[derive(Serialize)]
+struct CopiedStateDetails<'a> {
+    violations: &'a [PropertyViolation],
+    snapshots: &'a [Snapshot],
+}
 
 #[derive(PartialEq, Properties)]
 pub struct StateDetailsProps {
@@ -18,6 +27,34 @@ pub struct StateDetailsProps {
 #[component]
 pub fn StateDetails(props: &StateDetailsProps) -> Html {
     let (container_ref, container_size) = use_container_size();
+    let copy_status = use_state(|| None::<bool>);
+    let copy_text = json::to_string_pretty(&CopiedStateDetails {
+        violations: &props.entry.violations,
+        snapshots: &props.entry.snapshots,
+    })
+    .expect("violations and snapshots should serialize");
+    let copy_details = {
+        let copy_status = copy_status.clone();
+        Callback::from(move |_: MouseEvent| {
+            let copy_status = copy_status.clone();
+            let promise = web_sys::window()
+                .expect("window should exist")
+                .navigator()
+                .clipboard()
+                .write_text(&copy_text);
+            spawn_local(async move {
+                copy_status.set(Some(JsFuture::from(promise).await.is_ok()));
+                let copy_status = copy_status.clone();
+                Timeout::new(2_000, move || copy_status.set(None)).forget();
+            });
+        })
+    };
+    let copy_label = match *copy_status {
+        None => "Copy violations and snapshots",
+        Some(true) => "Copied violations and snapshots",
+        Some(false) => "Failed to copy violations and snapshots",
+    };
+
     html!(
         <>
             <details open={true} ref={container_ref} class={if props.entry.violations.is_empty() {""} else {"has-violations"}}>
@@ -35,6 +72,29 @@ pub fn StateDetails(props: &StateDetailsProps) -> Html {
                 <summary>
                 {format!("Violations ({})", props.entry.violations.len())}
                 </summary>
+                {if props.entry.violations.is_empty() {
+                    html!()
+                } else {
+                    html!(<button
+                        type="button"
+                        class="copy-details"
+                        onclick={copy_details}
+                        aria-label={copy_label}
+                        aria-live="polite"
+                        title={copy_label}
+                    >
+                        {if *copy_status == Some(true) {
+                            html!(<svg viewBox="0 0 16 16" aria-hidden="true">
+                                <path d="m3 8.5 3 3 7-7" />
+                            </svg>)
+                        } else {
+                            html!(<svg viewBox="0 0 16 16" aria-hidden="true">
+                                <rect x="5.5" y="5.5" width="8" height="8" rx="1" />
+                                <path d="M10.5 5.5V3.5a1 1 0 0 0-1-1h-6a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2" />
+                            </svg>)
+                        }}
+                    </button>)
+                }}
                 <ol>
                 {
                     props


### PR DESCRIPTION
# Background
During debugging of violations, I end up copying and pasting manually a lot from `bombadil inspect` into my agent. A copy button would make it really easy to do so. Sometimes the snapshots can be really long and harder to copy to clipboard. 

# Demo
https://github.com/user-attachments/assets/0e8de632-48ca-46cb-96b3-c2e74b4d1e71

The changes end up adding `Navigator` and `Clipboard` as new crates. Because I implemented a copy feedback with a checkmark, the callbacks, timers, and `JsFuture` seems to add some extra code to support that functionality. Open to feedback if its too verbose and we can trim it away and just have a static copy button. Also tagging that this is LLM-aided work since I am new to Rust