### PR TITLE
fix(DX Improvement): quote URLs in reproduction commands

### DIFF
--- a/lib/bombadil-cli/src/browser.rs
+++ b/lib/bombadil-cli/src/browser.rs
@@ -313,7 +313,10 @@ fn reproduce_command_args(
     subcommand: &str,
     shared: &TestSharedOptions,
 ) -> Vec<String> {
-    let mut args = vec![subcommand.to_string(), shared.origin.url.to_string()];
+    let mut args = vec![
+        subcommand.to_string(),
+        shell_quote(shared.origin.url.as_str()),
+    ];
     if let Some(path) = &shared.specification_file {
         args.push(path.display().to_string());
     }
@@ -338,6 +341,10 @@ fn reproduce_command_args(
         args.push(format!("--cookie {cookie}"));
     }
     args
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 async fn resolve_test_mode(


### PR DESCRIPTION
# Background
At the end of a bombadil run, the cli prints out a command to reproduce issues. 

 ```
   bombadil browser test \
     http://localhost:4321/test/?bombadil-testing=true&run-id=1787083809597 \
     tests/bombadil.spec.ts \
     --reproduce /path/to/trace
 ```
 
 In `zsh` the `?` and `&` from `http://localhost:4321/test/?bombadil-testing=true&run-id=1787083809597` gets interpreted as wildcard and background operator. This ends up breaking the command when ran. 
 
 
<img width="699" height="203" alt="Screenshot 2026-08-24 at 2 49 32 PM" src="https://github.com/user-attachments/assets/27192a7a-b543-43fd-bc2d-62ad2de856ba" />

Users may end up having zsh shorthand characters in their URLs, an easy way to support this will be to wrap the target url with quotes. 

 ```
   bombadil browser test \
     'http://localhost:4321/test/?bombadil-testing=true&run-id=1787083809597' \
     tests/bombadil.spec.ts \
     --reproduce /Users/vehbikaraagac/Desktop/anta/tests/.bombadil-1787083809597
 ```