### PR TITLE
nix: make hotpath an opt-in command

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,10 @@
             type = "app";
             program = "${self.packages.${system}.nix-build-push}/bin/nix-build-push";
           };
+          hotpath = {
+            type = "app";
+            program = "${pkgs.callPackage ./lib/nix/cargo-hotpath.nix { }}/bin/hotpath";
+          };
         };
 
         checks = {
@@ -116,7 +120,6 @@
               # nativeBuildInputs takes priority over inputsFrom in
               # PATH, so rustToolchainWasm shadows crane's toolchain.
               nativeBuildInputs = [ rustToolchainWasm ];
-              packages = [ (pkgs.callPackage ./lib/nix/cargo-hotpath.nix { }) ];
               buildInputs =
                 with pkgs;
                 [

--- a/lib/release/main.py
+++ b/lib/release/main.py
@@ -164,14 +164,12 @@ def main() -> None:
     def tag_release() -> None:
         nonlocal tag
         assert new_version is not None
-        print(
-            f"""
+        print(f"""
   {bold('What to do next:')}
   1. Review the PR on GitHub and let CI pass.
   2. Merge the PR (squash merge).
   3. Come back here and press Enter.
-"""
-        )
+""")
         pause("Press Enter after the PR has been merged…")
 
         run("git fetch")


### PR DESCRIPTION
To verify:
```
nix build .#default 
nix path-info --recursive .#default | rg -i hotpath
```

`nix flake show` output:
```
├───apps
│   ├───aarch64-darwin
│   │   ├───default: app
│   │   ├───hotpath: app
│   │   └───nix-build-push: app
│   ├───aarch64-linux omitted (use '--all-systems' to show)
│   ├───x86_64-darwin omitted (use '--all-systems' to show)
│   └───x86_64-linux omitted (use '--all-systems' to show)
├───checks
│   ├───aarch64-darwin
│   │   ├───clippy: CI test
│   │   ├───fmt: CI test
│   │   └───npm-package: CI test
│   ├───aarch64-linux omitted (use '--all-systems' to show)
│   ├───x86_64-darwin omitted (use '--all-systems' to show)
│   └───x86_64-linux omitted (use '--all-systems' to show)
├───devShells
│   ├───aarch64-darwin
│   │   ├───default: development environment
│   │   ├───manual: development environment
│   │   └───release: development environment
│   ├───aarch64-linux omitted (use '--all-systems' to show)
│   ├───x86_64-darwin omitted (use '--all-systems' to show)
│   └───x86_64-linux omitted (use '--all-systems' to show)
└───packages
    ├───aarch64-darwin
    │   ├───default: package
    │   ├───hotpath: package
    │   ├───manual: package
    │   ├───nix-build-push: package
    │   ├───npm-package: package
    │   └───release: package
    ├───aarch64-linux omitted (use '--all-systems' to show)
    ├───x86_64-darwin omitted (use '--all-systems' to show)
    └───x86_64-linux omitted (use '--all-systems' to show)
```