### PR TITLE
fix: handle additional frame navigation/load events

### DIFF
--- a/lib/bombadil-browser/src/browser.rs
+++ b/lib/bombadil-browser/src/browser.rs
@@ -6,7 +6,7 @@ use cdp::types::try_match;
 use cdp_protocol::cdp::browser_protocol::emulation;
 use cdp_protocol::cdp::browser_protocol::network;
 use cdp_protocol::cdp::browser_protocol::page::{
-    self, ClientNavigationReason, FrameId, NavigationType,
+    self, FrameId, NavigationType,
 };
 use cdp_protocol::cdp::browser_protocol::target::{self, SessionId, TargetId};
 use cdp_protocol::cdp::browser_protocol::{browser, dom};
@@ -102,9 +102,10 @@ enum InnerEvent {
         call_frame_id: Option<CallFrameId>,
     },
     Resumed,
-    FrameRequestedNavigation {
+    FrameNavigating {
         frame_id: FrameId,
-        reason: ClientNavigationReason,
+        // Only available after EventFrameRequestedNavigation.
+        reason: Option<page::ClientNavigationReason>,
         url: String,
     },
     FrameNavigated(FrameId, NavigationType),
@@ -642,9 +643,18 @@ fn forward_inner_events(
                     },
                     page::EventFrameRequestedNavigation: nav => {
                         if nav.frame_id == frame_id {
-                            Some(InnerEvent::FrameRequestedNavigation {
+                            Some(InnerEvent::FrameNavigating {
                                 frame_id: nav.frame_id.clone(),
-                                reason: nav.reason.clone(),
+                                reason: Some(nav.reason.clone()),
+                                url: nav.url.clone(),
+                            })
+                        } else { None }
+                    },
+                    page::EventFrameStartedNavigating: nav => {
+                        if nav.frame_id == frame_id {
+                            Some (InnerEvent::FrameNavigating{
+                                frame_id:nav.frame_id.clone(), 
+                                reason: None, 
                                 url: nav.url.clone(),
                             })
                         } else { None }
@@ -656,6 +666,9 @@ fn forward_inner_events(
                                     nav.r#type.clone(),
                             ))
                         } else { None }
+                    },
+                    page::EventFrameStoppedLoading: _ => {
+                        Some(InnerEvent::Loaded)
                     },
                     browser::EventDownloadWillBegin: event => {
                         if event.frame_id == frame_id {
@@ -937,10 +950,13 @@ fn process_event(
                 exceptions,
                 screenshot,
                 generation,
-            ).with_context(|| format!(
-                "state capture failed: generation={}, session={:?}, call_frame={:?}",
-                generation, context.session_id, call_frame_id,
-            ))?;
+            )
+            .with_context(|| {
+                format!(
+                    "state capture failed: generation={}, session={:?}, call_frame={:?}",
+                    generation, context.session_id, call_frame_id,
+                )
+            })?;
 
             context
                 .sender
@@ -1086,7 +1102,7 @@ fn process_event(
         }
         (
             InnerState { shared, kind },
-            InnerEvent::FrameRequestedNavigation {
+            InnerEvent::FrameNavigating {
                 frame_id,
                 reason,
                 url,


### PR DESCRIPTION
Fixes issues where quiescence timers were racing against reload/back/forward navigation and the browser state machine having stale information about the state of chrome. This manifested as `Error -32000: Can only perform operation while paused.`.