### PR TITLE
perf(browser): overlap independent CDP capture requests

### DIFF
--- a/lib/bombadil-browser/src/browser.rs
+++ b/lib/bombadil-browser/src/browser.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, ensure};
 use anyhow::{Result, anyhow, bail};
 use base64::Engine;
 use cdp::Binary;
+use cdp::MethodType;
 use cdp::types::try_match;
 use cdp_protocol::cdp::browser_protocol::emulation;
 use cdp_protocol::cdp::browser_protocol::network;
@@ -542,7 +543,21 @@ fn forward_inner_events(
     events_tx: mpmc::Sender<InnerEvent>,
 ) -> Result<()> {
     let event_source = connection.events.clone();
-    let events = connection.events.all();
+    let events = connection.events.methods([
+        runtime::EventExecutionContextCreated::method_id(),
+        runtime::EventExecutionContextDestroyed::method_id(),
+        page::EventLoadEventFired::method_id(),
+        debugger::EventPaused::method_id(),
+        debugger::EventResumed::method_id(),
+        runtime::EventExceptionThrown::method_id(),
+        page::EventFrameRequestedNavigation::method_id(),
+        page::EventFrameStartedNavigating::method_id(),
+        page::EventFrameNavigated::method_id(),
+        page::EventFrameStoppedLoading::method_id(),
+        browser::EventDownloadWillBegin::method_id(),
+        target::EventTargetDestroyed::method_id(),
+        runtime::EventConsoleApiCalled::method_id(),
+    ]);
 
     let _ = thread::spawn(move || {
         let error_tx = events_tx.clone();

--- a/lib/bombadil-browser/src/browser/activity.rs
+++ b/lib/bombadil-browser/src/browser/activity.rs
@@ -3,6 +3,7 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::Result;
+use cdp::MethodType;
 use cdp::types::try_match;
 use cdp_protocol::cdp::browser_protocol::{network, page};
 use crossbeam_channel as mpmc;
@@ -61,7 +62,11 @@ impl Drop for ActivityStream {
 }
 
 pub fn all_activity(events: &cdp::Events) -> Result<ActivityStream> {
-    let all = events.all();
+    let all = events.methods([
+        network::EventRequestWillBeSent::method_id(),
+        network::EventResponseReceived::method_id(),
+        page::EventScreencastFrame::method_id(),
+    ]);
     let (activity_tx, activity_rx) = mpmc::unbounded();
     let (cancel_tx, cancel_rx) = mpmc::bounded(1);
 

--- a/lib/bombadil-browser/src/browser/evaluation.rs
+++ b/lib/bombadil-browser/src/browser/evaluation.rs
@@ -15,8 +15,24 @@ pub fn evaluate_expression_in_debugger<Output: DeserializeOwned>(
     call_frame_id: &debugger::CallFrameId,
     expression: impl Into<String>,
 ) -> Result<Output> {
-    let returns: debugger::EvaluateOnCallFrameReturns = connection
-        .send(
+    let response = request_expression_in_debugger(
+        connection,
+        session_id,
+        call_frame_id,
+        expression,
+    )?
+    .wait()?;
+    parse_expression_response(response)
+}
+
+pub fn request_expression_in_debugger(
+    connection: &cdp::Connection,
+    session_id: &SessionId,
+    call_frame_id: &debugger::CallFrameId,
+    expression: impl Into<String>,
+) -> Result<cdp::PendingResponse<debugger::EvaluateOnCallFrameParams>> {
+    connection
+        .request(
             debugger::EvaluateOnCallFrameParams::builder()
                 .call_frame_id(call_frame_id.clone())
                 .expression(expression)
@@ -26,7 +42,12 @@ pub fn evaluate_expression_in_debugger<Output: DeserializeOwned>(
                 .map_err(|err| anyhow!(err))?,
             Some(session_id),
         )
-        .map_err(|err| anyhow!(err))?;
+        .map_err(|err| anyhow!(err))
+}
+
+pub fn parse_expression_response<Output: DeserializeOwned>(
+    returns: debugger::EvaluateOnCallFrameReturns,
+) -> Result<Output> {
     if let Some(exception) = returns.exception_details {
         bail!(
             "evaluate_function failed: {}",

--- a/lib/bombadil-browser/src/browser/evaluation.rs
+++ b/lib/bombadil-browser/src/browser/evaluation.rs
@@ -54,7 +54,7 @@ pub fn parse_expression_response<Output: DeserializeOwned>(
             format_exception_details(&exception)
         )
     } else {
-        match returns.result.value.clone() {
+        match returns.result.value {
             Some(value) => json::from_value(value).map_err(|err| anyhow!(err)),
             None => {
                 if let Some(runtime::RemoteObjectSubtype::Null) =

--- a/lib/bombadil-browser/src/browser/state.rs
+++ b/lib/bombadil-browser/src/browser/state.rs
@@ -1,6 +1,4 @@
-use crate::instrumentation::js::{
-    EDGE_MAP_SIZE, EDGES_CURRENT, EDGES_PREVIOUS, NAMESPACE,
-};
+use crate::instrumentation::js::{EDGES_CURRENT, EDGES_PREVIOUS, NAMESPACE};
 use anyhow::{Context, Result};
 use cdp_protocol::cdp::browser_protocol::target::SessionId;
 use cdp_protocol::cdp::{
@@ -10,6 +8,7 @@ use cdp_protocol::cdp::{
     },
     js_protocol::debugger::CallFrameId,
 };
+use const_format::formatcp;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json as json;
 use std::time::SystemTime;
@@ -237,7 +236,7 @@ impl BrowserState {
             connection,
             session_id,
             call_frame_id,
-            format!(
+            formatcp!(
                 "
                 (() => {{
                     const snapshot = (edgesNew, transitionHash) => ({{
@@ -292,8 +291,12 @@ impl BrowserState {
                         }}
                     }}
 
+                    // Reuse the previous buffer for the next capture. Clear it
+                    // here even when the transition hash will return null.
+                    const reusable = coverage.{EDGES_PREVIOUS};
                     coverage.{EDGES_PREVIOUS} = coverage.{EDGES_CURRENT};
-                    coverage.{EDGES_CURRENT} = new Uint8Array({EDGE_MAP_SIZE});
+                    reusable.fill(0);
+                    coverage.{EDGES_CURRENT} = reusable;
 
                     if (similarityWeights.every(weight => weight === 0)) {{
                         return snapshot(differences, null);
@@ -330,31 +333,31 @@ impl BrowserState {
 
         let url = Url::parse(&runtime_state.url)?;
 
-        let navigation_entries = navigation_history_result
+        let index = navigation_history_result.current_index as usize;
+        let mut navigation_entries = navigation_history_result
             .entries
-            .iter()
+            .into_iter()
             .map(|entry| NavigationEntry {
                 id: entry.id as u32,
-                title: entry.title.clone(),
+                title: entry.title,
                 url: Url::parse(&entry.url)
                     .expect("url from getNavigationHistory doesn't parse"),
-            })
-            .collect::<Vec<_>>();
-        let index = navigation_history_result.current_index as usize;
+            });
         let is_real_entry =
-            |entry: &&NavigationEntry| entry.url.as_str() != "about:blank";
+            |entry: &NavigationEntry| entry.url.as_str() != "about:blank";
+        let back = navigation_entries
+            .by_ref()
+            .take(index)
+            .filter(is_real_entry)
+            .collect();
+        let current = navigation_entries
+            .next()
+            .expect("current navigation entry missing from history");
+        let forward = navigation_entries.filter(is_real_entry).collect();
         let navigation_history = NavigationHistory {
-            back: navigation_entries[0..index]
-                .iter()
-                .filter(is_real_entry)
-                .cloned()
-                .collect(),
-            current: navigation_entries[index].clone(),
-            forward: navigation_entries[index + 1..]
-                .iter()
-                .filter(is_real_entry)
-                .cloned()
-                .collect(),
+            back,
+            current,
+            forward,
         };
 
         let transition_hash = match runtime_state.transition_hash {

--- a/lib/bombadil-browser/src/browser/state.rs
+++ b/lib/bombadil-browser/src/browser/state.rs
@@ -16,8 +16,8 @@ use std::time::SystemTime;
 use url::Url;
 
 use crate::browser::evaluation::{
-    evaluate_expression_in_debugger, evaluate_function_call_in_debugger,
-    evaluate_script_in_debugger,
+    evaluate_function_call_in_debugger, evaluate_script_in_debugger,
+    parse_expression_response, request_expression_in_debugger,
 };
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
@@ -233,7 +233,7 @@ impl BrowserState {
         generation: Generation,
     ) -> Result<Self> {
         log::trace!("BrowserState::current: requesting CDP state");
-        let runtime_state: RuntimeStateSnapshot = evaluate_expression_in_debugger(
+        let runtime_state = request_expression_in_debugger(
             connection,
             session_id,
             call_frame_id,
@@ -308,9 +308,21 @@ impl BrowserState {
                 }})()
                 "
             ),
-        ).context("evaluating capture runtime state")?;
-        let navigation_history_result = connection
-            .send(page::GetNavigationHistoryParams {}, Some(session_id))
+        ).context("requesting capture runtime state")?;
+        let navigation_history = connection
+            .request(page::GetNavigationHistoryParams {}, Some(session_id))
+            .context("requesting capture navigation history")?;
+
+        // Navigation history is independent of runtime evaluation. Metrics must
+        // follow the coverage and transition-hash work in the runtime snapshot.
+        let runtime_state: RuntimeStateSnapshot = parse_expression_response(
+            runtime_state
+                .wait()
+                .context("evaluating capture runtime state")?,
+        )
+        .context("parsing capture runtime state")?;
+        let navigation_history_result = navigation_history
+            .wait()
             .context("reading capture navigation history")?;
         let performance_metrics_result = connection
             .send(performance::GetMetricsParams {}, Some(session_id))

--- a/lib/bombadil-browser/src/browser/state.rs
+++ b/lib/bombadil-browser/src/browser/state.rs
@@ -182,10 +182,13 @@ pub struct Resources {
 
 impl Resources {
     pub fn from_metrics(metrics: &[performance::Metric]) -> Self {
-        use std::collections::BTreeMap;
-        let map: BTreeMap<&str, f64> =
-            metrics.iter().map(|m| (m.name.as_str(), m.value)).collect();
-        let get = |name: &str| -> f64 { map.get(name).copied().unwrap_or(0.0) };
+        let get = |name: &str| -> f64 {
+            metrics
+                .iter()
+                .rev()
+                .find(|m| m.name == name)
+                .map_or(0.0, |m| m.value)
+        };
         Self {
             js_heap_used: get("JSHeapUsedSize") as u64,
             js_heap_total: get("JSHeapTotalSize") as u64,

--- a/lib/bombadil-browser/src/trace/writer.rs
+++ b/lib/bombadil-browser/src/trace/writer.rs
@@ -1,4 +1,9 @@
-use std::{borrow::Cow, io::Write, path::PathBuf, time::UNIX_EPOCH};
+use std::{
+    borrow::Cow,
+    io::{BufWriter, Write},
+    path::PathBuf,
+    time::UNIX_EPOCH,
+};
 
 use anyhow::Result;
 use bombadil::specification::domain::Snapshot;
@@ -14,7 +19,7 @@ use crate::{
 
 pub struct FileTraceWriter {
     screenshots_path: PathBuf,
-    trace_file: File,
+    trace_file: BufWriter<File>,
     last_transition_hash: Option<u64>,
 }
 
@@ -48,7 +53,7 @@ impl FileTraceWriter {
             .open(&trace_file_path)?;
         Ok(FileTraceWriter {
             screenshots_path,
-            trace_file,
+            trace_file: BufWriter::new(trace_file),
             last_transition_hash: None,
         })
     }
@@ -84,9 +89,9 @@ impl TraceWriter for FileTraceWriter {
 
         self.last_transition_hash = state.transition_hash;
 
-        self.trace_file
-            .write_all(json::to_string(&entry.to_schema())?.as_bytes())?;
+        json::to_writer(&mut self.trace_file, &entry.to_schema())?;
         self.trace_file.write_all(b"\n")?;
+        self.trace_file.flush()?;
 
         Ok(())
     }

--- a/lib/bombadil-ltl/src/eval.rs
+++ b/lib/bombadil-ltl/src/eval.rs
@@ -131,18 +131,18 @@ impl<'a, D: Domain, Error> Evaluator<'a, D, Error> {
                 let (formula, state) =
                     (self.evaluate_thunk)(function, *negated)?;
                 let mut value = self.evaluate(&formula, time)?;
-                attach_state(&mut value, &state);
+                attach_state(&mut value, state);
                 Ok(value)
             }
             Formula::And(left, right) => {
                 let left = self.evaluate(left.as_ref(), time)?;
                 let right = self.evaluate(right.as_ref(), time)?;
-                Ok(self.evaluate_and(&left, &right))
+                Ok(self.evaluate_and(left, right))
             }
             Formula::Or(left, right) => {
                 let left = self.evaluate(left.as_ref(), time)?;
                 let right = self.evaluate(right.as_ref(), time)?;
-                Ok(self.evaluate_or(&left, &right))
+                Ok(self.evaluate_or(left, right))
             }
             Formula::Implies(left_formula, right) => {
                 let left = self.evaluate(left_formula.as_ref(), time)?;
@@ -167,7 +167,7 @@ impl<'a, D: Domain, Error> Evaluator<'a, D, Error> {
         }
     }
 
-    fn evaluate_and(&mut self, left: &Value<D>, right: &Value<D>) -> Value<D> {
+    fn evaluate_and(&mut self, left: Value<D>, right: Value<D>) -> Value<D> {
         fn combine_and<D: Domain>(
             left: Residual<D>,
             right: Residual<D>,
@@ -180,29 +180,25 @@ impl<'a, D: Domain, Error> Evaluator<'a, D, Error> {
 
         match (left, right) {
             (Value::True(left_state), Value::True(right_state)) => {
-                Value::True(left_state.merge(right_state))
+                Value::True(left_state.merge(&right_state))
             }
-            (Value::True(state), Value::Residual(residual)) => Value::Residual(
-                combine_and(Residual::True(state.clone()), residual.clone()),
-            ),
-            (Value::Residual(residual), Value::True(state)) => Value::Residual(
-                combine_and(residual.clone(), Residual::True(state.clone())),
-            ),
-            (Value::True(_), right) => right.clone(),
-            (left, Value::True(_)) => left.clone(),
+            (Value::True(state), Value::Residual(residual)) => {
+                Value::Residual(combine_and(Residual::True(state), residual))
+            }
+            (Value::Residual(residual), Value::True(state)) => {
+                Value::Residual(combine_and(residual, Residual::True(state)))
+            }
+            (Value::True(_), right) => right,
+            (left, Value::True(_)) => left,
             (
                 Value::False(violation_left, residual_left),
                 Value::False(violation_right, residual_right),
             ) => Value::False(
                 Violation::And {
-                    left: Box::new(violation_left.clone()),
-                    right: Box::new(violation_right.clone()),
+                    left: Box::new(violation_left),
+                    right: Box::new(violation_right),
                 },
-                combine_options(
-                    residual_left.clone(),
-                    residual_right.clone(),
-                    combine_and,
-                ),
+                combine_options(residual_left, residual_right, combine_and),
             ),
             (
                 Value::Residual(residual),
@@ -213,32 +209,30 @@ impl<'a, D: Domain, Error> Evaluator<'a, D, Error> {
                 Value::Residual(residual),
             ) => {
                 let continuation = match continuation {
-                    Some(continuation) => {
-                        combine_and(residual.clone(), continuation.clone())
-                    }
-                    None => residual.clone(),
+                    Some(continuation) => combine_and(residual, continuation),
+                    None => residual,
                 };
-                Value::False(violation.clone(), Some(continuation))
+                Value::False(violation, Some(continuation))
             }
             (Value::Residual(left), Value::Residual(right)) => {
-                Value::Residual(combine_and(left.clone(), right.clone()))
+                Value::Residual(combine_and(left, right))
             }
         }
     }
 
-    fn evaluate_or(&mut self, left: &Value<D>, right: &Value<D>) -> Value<D> {
+    fn evaluate_or(&mut self, left: Value<D>, right: Value<D>) -> Value<D> {
         match (left, right) {
             (
                 Value::False(violation_left, residual_left),
                 Value::False(violation_right, residual_right),
             ) => Value::False(
                 Violation::Or {
-                    left: Box::new(violation_left.clone()),
-                    right: Box::new(violation_right.clone()),
+                    left: Box::new(violation_left),
+                    right: Box::new(violation_right),
                 },
                 combine_options(
-                    residual_left.clone(),
-                    residual_right.clone(),
+                    residual_left,
+                    residual_right,
                     |left, right| Residual::Or {
                         left: Box::new(left),
                         right: Box::new(right),
@@ -246,16 +240,16 @@ impl<'a, D: Domain, Error> Evaluator<'a, D, Error> {
                 ),
             ),
             (Value::True(left_state), Value::True(right_state)) => {
-                Value::True(left_state.merge(right_state))
+                Value::True(left_state.merge(&right_state))
             }
-            (Value::True(state), _) => Value::True(state.clone()),
-            (_, Value::True(state)) => Value::True(state.clone()),
-            (left, Value::False(_, _)) => left.clone(),
-            (Value::False(_, _), right) => right.clone(),
+            (Value::True(state), _) => Value::True(state),
+            (_, Value::True(state)) => Value::True(state),
+            (left, Value::False(_, _)) => left,
+            (Value::False(_, _), right) => right,
             (Value::Residual(left), Value::Residual(right)) => {
                 Value::Residual(Residual::Or {
-                    left: Box::new(left.clone()),
-                    right: Box::new(right.clone()),
+                    left: Box::new(left),
+                    right: Box::new(right),
                 })
             }
         }
@@ -664,12 +658,12 @@ impl<'a, D: Domain, Error> Evaluator<'a, D, Error> {
             Residual::And { left, right } => {
                 let left = self.step(left, time)?;
                 let right = self.step(right, time)?;
-                self.evaluate_and(&left, &right)
+                self.evaluate_and(left, right)
             }
             Residual::Or { left, right } => {
                 let left = self.step(left, time)?;
                 let right = self.step(right, time)?;
-                self.evaluate_or(&left, &right)
+                self.evaluate_or(left, right)
             }
             Residual::Implies {
                 left_formula,
@@ -748,19 +742,23 @@ impl<'a, D: Domain, Error> Evaluator<'a, D, Error> {
     }
 }
 
-fn attach_state<D: Domain>(value: &mut Value<D>, resolved: &D::State) {
+fn attach_state<D: Domain>(value: &mut Value<D>, resolved: D::State) {
     if resolved.is_empty() {
         return;
     }
     match value {
         Value::True(state) => {
-            *state = state.merge(resolved);
+            *state = if state.is_empty() {
+                resolved
+            } else {
+                state.merge(&resolved)
+            };
         }
         Value::False(violation, _) => {
-            attach_to_violation(violation, resolved);
+            attach_to_violation(violation, &resolved);
         }
         Value::Residual(residual) => {
-            attach_to_residual(residual, resolved);
+            attach_to_residual(residual, &resolved);
         }
     }
 }

--- a/lib/bombadil/src/runner.rs
+++ b/lib/bombadil/src/runner.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use antithesis_sdk::assert::{AssertType, assert_raw};
 use anyhow::Result;
 use bombadil_ltl::eval;
@@ -90,6 +88,7 @@ impl<D: InterfaceDriver> Runner<D> {
         strategy: &mut S,
     ) -> Result<S::StopValue> {
         let mut last_action: Option<D::Action> = None;
+        let mut violations = Vec::new();
 
         loop {
             let event = driver.next_event();
@@ -102,9 +101,10 @@ impl<D: InterfaceDriver> Runner<D> {
 
             match event {
                 Some(DriverEvent::StateChanged(state)) => {
-                    let snapshots: Arc<[Snapshot]> = driver
-                        .extract_snapshots(state.clone(), last_action.as_ref())?
-                        .into();
+                    let snapshots = driver.extract_snapshots(
+                        state.clone(),
+                        last_action.as_ref(),
+                    )?;
                     for value in snapshots.iter() {
                         log::debug!(
                             "snapshot {}: {}",
@@ -118,8 +118,7 @@ impl<D: InterfaceDriver> Runner<D> {
                         Time::from_system_time(D::state_timestamp(&state)),
                     )?;
 
-                    let mut violations =
-                        Vec::with_capacity(step_result.properties.len());
+                    violations.clear();
                     for (name, value) in step_result.properties {
                         let (condition, hit, details) = match value {
                             eval::Value::False(violation, _) => {

--- a/lib/bombadil/src/runner.rs
+++ b/lib/bombadil/src/runner.rs
@@ -124,7 +124,7 @@ impl<D: InterfaceDriver> Runner<D> {
                         let (condition, hit, details) = match value {
                             eval::Value::False(violation, _) => {
                                 let violation =
-                                    violation_with_pretty_functions(&violation)
+                                    violation_with_pretty_functions(violation)
                                         .to_schema();
                                 violations.push(PropertyViolation {
                                     name: name.clone(),

--- a/lib/bombadil/src/runner.rs
+++ b/lib/bombadil/src/runner.rs
@@ -119,7 +119,7 @@ impl<D: InterfaceDriver> Runner<D> {
                     )?;
 
                     violations.clear();
-                    for (name, value) in step_result.properties {
+                    for (name, value) in step_result.properties() {
                         let (condition, hit, details) = match value {
                             eval::Value::False(violation, _) => {
                                 let violation =

--- a/lib/bombadil/src/specification/snapshots.rs
+++ b/lib/bombadil/src/specification/snapshots.rs
@@ -1,4 +1,6 @@
-use boa_engine::{Context, JsValue, js_string};
+use boa_engine::{
+    Context, JsValue, js_string, object::builtins::JsArray, value::TryFromJs,
+};
 
 use crate::specification::js::BombadilExports;
 use crate::specification::result::{Result, SpecificationError};
@@ -7,7 +9,7 @@ pub fn with_snapshot_tracking<R>(
     context: &mut Context,
     bombadil_exports: &BombadilExports,
     f: impl FnOnce(&mut Context) -> Result<R>,
-) -> Result<(Vec<usize>, R)> {
+) -> Result<(JsArray, R)> {
     let runtime = bombadil_exports.runtime.clone();
 
     let start = runtime
@@ -28,15 +30,7 @@ pub fn with_snapshot_tracking<R>(
     let result = f(context);
     let accesses_js =
         stop.call(&JsValue::from(runtime.clone()), &[], context)?;
-    let indices = serde_json::from_value(
-        accesses_js.to_json(context)?.unwrap_or_default(),
-    )
-    .map_err(|error| {
-        SpecificationError::OtherError(format!(
-            "failed to deserialize extractor indices: {}",
-            error
-        ))
-    })?;
+    let indices = JsArray::try_from_js(&accesses_js, context)?;
 
     Ok((indices, result?))
 }

--- a/lib/bombadil/src/specification/verifier.rs
+++ b/lib/bombadil/src/specification/verifier.rs
@@ -12,7 +12,7 @@ use boa_engine::{
     js_string, object::builtins::JsArray, property::PropertyKey,
 };
 use boa_engine::{JsObject, JsValue, value::TryFromJs};
-use bombadil_ltl::eval::{self, Evaluator, Residual};
+use bombadil_ltl::eval::{self, Evaluator};
 use bombadil_ltl::formula::Formula;
 use bombadil_ltl::syntax::Syntax;
 use serde_json as json;
@@ -21,18 +21,31 @@ use crate::specification::domain::{BombadilDomain, Snapshot, UniqueSnapshots};
 
 #[derive(Clone)]
 pub struct StepResult<'a, A> {
-    pub properties:
-        &'a [(String, eval::Value<BombadilDomain<RuntimeFunction>>)],
+    properties: &'a HashMap<String, Property>,
     pub actions: Tree<A>,
     pub all_definite: bool,
+}
+
+impl<A> StepResult<'_, A> {
+    pub fn properties(
+        &self,
+    ) -> impl Iterator<Item = (&String, &eval::Value<BombadilDomain<RuntimeFunction>>)>
+    {
+        self.properties
+            .values()
+            .filter_map(|property| match &property.state {
+                PropertyState::Evaluated(value) => {
+                    Some((&property.name, value))
+                }
+                _ => None,
+            })
+    }
 }
 
 pub struct Verifier {
     context: Context,
     bombadil_exports: BombadilExports,
     properties: HashMap<String, Property>,
-    result_properties:
-        Vec<(String, eval::Value<BombadilDomain<RuntimeFunction>>)>,
     action_generators: HashMap<String, ActionGenerator>,
     extractors: Extractors,
 }
@@ -232,7 +245,6 @@ impl Verifier {
 
         Ok(Verifier {
             context,
-            result_properties: Vec::with_capacity(properties.len()),
             properties,
             action_generators,
             bombadil_exports,
@@ -252,7 +264,6 @@ impl Verifier {
     ) -> Result<StepResult<'_, A>> {
         self.extractors
             .update_from_snapshots(snapshots, &mut self.context)?;
-        self.result_properties.clear();
         let mut generator_branches: Vec<(u16, Tree<A>)> = Vec::new();
 
         let context = &mut self.context;
@@ -304,33 +315,21 @@ impl Verifier {
                 PropertyState::Initial(formula) => {
                     evaluator.evaluate(formula, time)?
                 }
-                PropertyState::Residual(residual) => {
-                    evaluator.step(residual, time)?
+                PropertyState::Evaluated(
+                    eval::Value::Residual(residual)
+                    | eval::Value::False(_, Some(residual)),
+                ) => evaluator.step(residual, time)?,
+                PropertyState::Evaluated(_) | PropertyState::Settled => {
+                    property.state = PropertyState::Settled;
+                    continue;
                 }
-                PropertyState::DefinitelyTrue
-                | PropertyState::DefinitelyFalse => continue,
             };
-            self.result_properties.push((
-                property.name.clone(),
-                match value {
-                    eval::Value::True(_) => {
-                        property.state = PropertyState::DefinitelyTrue;
-                        eval::Value::True(UniqueSnapshots::default())
-                    }
-                    eval::Value::False(violation, continuation) => {
-                        property.state = match continuation {
-                            Some(residual) => PropertyState::Residual(residual),
-                            None => PropertyState::DefinitelyFalse,
-                        };
-                        eval::Value::False(violation, None)
-                    }
-                    eval::Value::Residual(residual) => {
-                        property.state =
-                            PropertyState::Residual(residual.clone());
-                        eval::Value::Residual(residual)
-                    }
-                },
-            ));
+            property.state = PropertyState::Evaluated(match value {
+                eval::Value::True(_) => {
+                    eval::Value::True(UniqueSnapshots::default())
+                }
+                value => value,
+            });
         }
 
         for action_generator in self.action_generators.values() {
@@ -345,12 +344,15 @@ impl Verifier {
         let all_definite = self.properties.values().all(|p| {
             matches!(
                 &p.state,
-                PropertyState::DefinitelyTrue | PropertyState::DefinitelyFalse
+                PropertyState::Settled
+                    | PropertyState::Evaluated(
+                        eval::Value::True(_) | eval::Value::False(_, None)
+                    )
             )
         });
 
         Ok(StepResult {
-            properties: &self.result_properties,
+            properties: &self.properties,
             actions: action_tree,
             all_definite,
         })
@@ -369,9 +371,8 @@ pub struct Property {
 #[derive(Debug, Clone)]
 enum PropertyState {
     Initial(Formula<BombadilDomain<RuntimeFunction>>),
-    Residual(Residual<BombadilDomain<RuntimeFunction>>),
-    DefinitelyTrue,
-    DefinitelyFalse,
+    Evaluated(eval::Value<BombadilDomain<RuntimeFunction>>),
+    Settled,
 }
 
 #[derive(Debug, Clone)]
@@ -503,7 +504,7 @@ mod tests {
             )
             .unwrap();
 
-        let (name, value) = result.properties.first().unwrap();
+        let (name, value) = result.properties().next().unwrap();
         assert_eq!(*name, "my_prop");
         assert!(matches!(value, eval::Value::True(_)));
     }
@@ -544,7 +545,7 @@ mod tests {
             )
             .unwrap();
 
-        let (name, value) = result.properties.first().unwrap();
+        let (name, value) = result.properties().next().unwrap();
         assert_eq!(*name, "my_prop");
         assert!(matches!(value, eval::Value::True(_)));
     }
@@ -585,7 +586,7 @@ mod tests {
             )
             .unwrap();
 
-        let (name, value) = result.properties.first().unwrap();
+        let (name, value) = result.properties().next().unwrap();
         assert_eq!(*name, "my_prop");
         assert!(matches!(value, eval::Value::True(_)));
     }
@@ -626,7 +627,7 @@ mod tests {
             )
             .unwrap();
 
-        let (name, value) = result.properties.first().unwrap();
+        let (name, value) = result.properties().next().unwrap();
         assert_eq!(*name, "my_prop");
         assert!(matches!(value, eval::Value::True(_)));
     }
@@ -658,7 +659,7 @@ mod tests {
                 )
                 .unwrap();
 
-            let (name, value) = result.properties.first().unwrap();
+            let (name, value) = result.properties().next().unwrap();
             assert_eq!(*name, "my_prop");
 
             if i == 1 {
@@ -704,7 +705,7 @@ mod tests {
                 )
                 .unwrap();
 
-            let (name, value) = result.properties.first().unwrap();
+            let (name, value) = result.properties().next().unwrap();
             assert_eq!(*name, "my_prop");
 
             if i == 100 {
@@ -742,7 +743,7 @@ mod tests {
                 time,
             )
             .unwrap();
-        let (name, value) = result.properties.first().unwrap();
+        let (name, value) = result.properties().next().unwrap();
         assert_eq!(*name, "my_prop");
         assert!(
             matches!(value, eval::Value::Residual(_)),
@@ -778,7 +779,7 @@ mod tests {
                 )
                 .unwrap();
 
-            if let Some((name, value)) = result.properties.first() {
+            if let Some((name, value)) = result.properties().next() {
                 assert_eq!(*name, "my_prop");
 
                 if i < 4 {
@@ -831,7 +832,7 @@ mod tests {
                 )
                 .unwrap();
 
-            let (name, value) = result.properties.first().unwrap();
+            let (name, value) = result.properties().next().unwrap();
             assert_eq!(*name, "my_prop");
 
             if i == 9 {
@@ -896,7 +897,7 @@ mod tests {
                 )
                 .unwrap();
 
-            if let Some((name, value)) = result.properties.first() {
+            if let Some((name, value)) = result.properties().next() {
                 assert_eq!(*name, "my_prop");
 
                 if i < 4 {
@@ -948,7 +949,7 @@ mod tests {
                     time_from_millis(0),
                 )
                 .unwrap();
-            let (_, value) = result.properties.first().unwrap();
+            let (_, value) = result.properties().next().unwrap();
             assert!(
                 matches!(value, eval::Value::Residual(_)),
                 "expected Residual at i={}, got: {:?}",
@@ -969,7 +970,7 @@ mod tests {
                 time_from_millis(0),
             )
             .unwrap();
-        let (_, value) = result.properties.first().unwrap();
+        let (_, value) = result.properties().next().unwrap();
         assert!(
             matches!(value, eval::Value::False(_, _)),
             "expected False at value=5, got: {:?}",
@@ -988,7 +989,7 @@ mod tests {
                 time_from_millis(0),
             )
             .unwrap();
-        let (_, value) = result.properties.first().unwrap();
+        let (_, value) = result.properties().next().unwrap();
         assert!(
             matches!(value, eval::Value::Residual(_)),
             "expected Residual after reset, got: {:?}",
@@ -1007,7 +1008,7 @@ mod tests {
                 time_from_millis(0),
             )
             .unwrap();
-        let (_, value) = result.properties.first().unwrap();
+        let (_, value) = result.properties().next().unwrap();
         assert!(
             matches!(value, eval::Value::False(_, _)),
             "expected new False at value=5, got: {:?}",
@@ -1042,7 +1043,7 @@ mod tests {
                 time,
             )
             .unwrap();
-        let (name, value) = result.properties.first().unwrap();
+        let (name, value) = result.properties().next().unwrap();
         assert_eq!(*name, "my_prop");
         assert!(
             matches!(value, eval::Value::False(_, None)),
@@ -1063,7 +1064,7 @@ mod tests {
             )
             .unwrap();
         assert!(
-            result.properties.is_empty(),
+            result.properties().next().is_none(),
             "expected no properties after terminal False, got: {:?}",
             result.properties,
         );
@@ -1095,7 +1096,7 @@ mod tests {
                 time_from_millis(0),
             )
             .unwrap();
-        let (_, value) = result.properties.first().unwrap();
+        let (_, value) = result.properties().next().unwrap();
         assert!(matches!(value, eval::Value::Residual(_)));
 
         // At time 3ms, value 10: fails the always, but has continuation
@@ -1110,12 +1111,13 @@ mod tests {
                 time_from_millis(3),
             )
             .unwrap();
-        let (_, value) = result.properties.first().unwrap();
+        let (_, value) = result.properties().next().unwrap();
         assert!(
             matches!(value, eval::Value::False(_, _)),
             "expected False at time 3ms, got: {:?}",
             value,
         );
+        assert!(!result.all_definite);
 
         // At time 4ms, value 0: should be Residual (reset via continuation)
         let result: StepResult<Snapshot> = verifier
@@ -1129,7 +1131,7 @@ mod tests {
                 time_from_millis(4),
             )
             .unwrap();
-        let (_, value) = result.properties.first().unwrap();
+        let (_, value) = result.properties().next().unwrap();
         assert!(
             matches!(value, eval::Value::Residual(_)),
             "expected Residual at time 4ms after reset, got: {:?}",
@@ -1148,11 +1150,12 @@ mod tests {
                 time_from_millis(6),
             )
             .unwrap();
-        let (_, value) = result.properties.first().unwrap();
+        let (_, value) = result.properties().next().unwrap();
         assert!(
             matches!(value, eval::Value::True(_)),
             "expected True past the bound, got: {:?}",
             value,
         );
+        assert!(result.all_definite);
     }
 }

--- a/lib/bombadil/src/specification/verifier.rs
+++ b/lib/bombadil/src/specification/verifier.rs
@@ -371,7 +371,11 @@ pub struct Property {
 #[derive(Debug, Clone)]
 enum PropertyState {
     Initial(Formula<BombadilDomain<RuntimeFunction>>),
+    // Keep the current result here so callers can borrow it without cloning.
+    // True and False without a continuation become Settled on the next step,
+    // after callers have had a chance to report them.
     Evaluated(eval::Value<BombadilDomain<RuntimeFunction>>),
+    // A terminal result from an earlier step; no longer emitted to callers.
     Settled,
 }
 

--- a/lib/bombadil/src/specification/verifier.rs
+++ b/lib/bombadil/src/specification/verifier.rs
@@ -11,7 +11,7 @@ use boa_engine::{
     Context, JsString, NativeFunction, Source, context::ContextBuilder,
     js_string, object::builtins::JsArray, property::PropertyKey,
 };
-use boa_engine::{JsObject, JsValue};
+use boa_engine::{JsObject, JsValue, value::TryFromJs};
 use bombadil_ltl::eval::{self, Evaluator, Residual};
 use bombadil_ltl::formula::Formula;
 use bombadil_ltl::syntax::Syntax;
@@ -268,11 +268,19 @@ impl Verifier {
                         .map_err(Into::into)
                 },
             )?;
-            let accessed_snapshots: UniqueSnapshots = indices
-                .into_iter()
-                .filter_map(|index| snapshots.get(index).cloned())
-                .map(|snapshot| ((snapshot.index, snapshot.time), snapshot))
-                .collect();
+            let accessed_snapshots: UniqueSnapshots = (0..indices
+                .length(context)?)
+                .map(|i| {
+                    let index = usize::try_from_js(
+                        &indices.at(i as i64, context)?,
+                        context,
+                    )?;
+                    Ok(snapshots.get(index).cloned().map(|snapshot| {
+                        ((snapshot.index, snapshot.time), snapshot)
+                    }))
+                })
+                .filter_map(|result: Result<Option<_>>| result.transpose())
+                .collect::<Result<_>>()?;
             let syntax =
                 syntax_from_value(&value, &self.bombadil_exports, context)?;
             Ok((

--- a/lib/bombadil/src/specification/verifier.rs
+++ b/lib/bombadil/src/specification/verifier.rs
@@ -20,8 +20,9 @@ use serde_json as json;
 use crate::specification::domain::{BombadilDomain, Snapshot, UniqueSnapshots};
 
 #[derive(Clone)]
-pub struct StepResult<A> {
-    pub properties: Vec<(String, eval::Value<BombadilDomain<RuntimeFunction>>)>,
+pub struct StepResult<'a, A> {
+    pub properties:
+        &'a [(String, eval::Value<BombadilDomain<RuntimeFunction>>)],
     pub actions: Tree<A>,
     pub all_definite: bool,
 }
@@ -30,6 +31,8 @@ pub struct Verifier {
     context: Context,
     bombadil_exports: BombadilExports,
     properties: HashMap<String, Property>,
+    result_properties:
+        Vec<(String, eval::Value<BombadilDomain<RuntimeFunction>>)>,
     action_generators: HashMap<String, ActionGenerator>,
     extractors: Extractors,
 }
@@ -229,6 +232,7 @@ impl Verifier {
 
         Ok(Verifier {
             context,
+            result_properties: Vec::with_capacity(properties.len()),
             properties,
             action_generators,
             bombadil_exports,
@@ -245,10 +249,10 @@ impl Verifier {
         &mut self,
         snapshots: &[Snapshot],
         time: bombadil_schema::Time,
-    ) -> Result<StepResult<A>> {
+    ) -> Result<StepResult<'_, A>> {
         self.extractors
             .update_from_snapshots(snapshots, &mut self.context)?;
-        let mut result_properties = Vec::with_capacity(self.properties.len());
+        self.result_properties.clear();
         let mut generator_branches: Vec<(u16, Tree<A>)> = Vec::new();
 
         let context = &mut self.context;
@@ -306,7 +310,7 @@ impl Verifier {
                 PropertyState::DefinitelyTrue
                 | PropertyState::DefinitelyFalse => continue,
             };
-            result_properties.push((
+            self.result_properties.push((
                 property.name.clone(),
                 match value {
                     eval::Value::True(_) => {
@@ -346,7 +350,7 @@ impl Verifier {
         });
 
         Ok(StepResult {
-            properties: result_properties,
+            properties: &self.result_properties,
             actions: action_tree,
             all_definite,
         })
@@ -487,7 +491,7 @@ mod tests {
 
         let time = time_from_millis(0);
 
-        let result: StepResult<Snapshot> = verifier
+        let result: StepResult<'_, Snapshot> = verifier
             .step(
                 &[Snapshot {
                     index: 0,

--- a/lib/cdp/examples/basic.rs
+++ b/lib/cdp/examples/basic.rs
@@ -15,7 +15,7 @@
 use std::env;
 
 use anyhow::{Result, anyhow, bail};
-use cdp::{Connection, Method};
+use cdp::{Connection, Method, MethodType};
 use cdp_protocol::cdp::{
     browser_protocol::{browser, page, target},
     js_protocol::runtime,
@@ -128,7 +128,11 @@ fn main() -> Result<()> {
         .ok_or(anyhow!("no execution context"))?;
     log::info!("Got page load.");
 
-    let residual = connection.events.all();
+    let residual = connection.events.methods([
+        runtime::EventExecutionContextDestroyed::method_id(),
+        runtime::EventExecutionContextsCleared::method_id(),
+        target::EventDetachedFromTarget::method_id(),
+    ]);
 
     if mode == Mode::Create {
         let _ = connection.send(
@@ -141,7 +145,7 @@ fn main() -> Result<()> {
 
     connection.close()?;
 
-    println!("Residual events:");
+    println!("Remaining context and detach events:");
     for event in residual {
         println!("${}: {}", event.method_name(), event.params.get());
     }

--- a/lib/cdp/src/conn.rs
+++ b/lib/cdp/src/conn.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 use std::io::ErrorKind;
+use std::marker::PhantomData;
 use std::net::TcpStream;
 use std::os::fd::{AsRawFd, RawFd};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use cdp_protocol::cdp::browser_protocol::target::SessionId;
 use crossbeam_channel as mpmc;
@@ -16,7 +17,9 @@ use tungstenite::protocol::WebSocketConfig;
 use tungstenite::stream::MaybeTlsStream;
 use tungstenite::{Message as WsMessage, WebSocket};
 
-use cdp_types::{CallId, CdpJsonEventMessage, Command, MethodCall, Response};
+use cdp_types::{
+    CallId, CdpJsonEventMessage, Command, MethodCall, MethodId, Response,
+};
 use serde::Deserialize;
 use serde::de::IgnoredAny;
 use serde_json as json;
@@ -48,12 +51,26 @@ impl Connection {
     }
 
     /// Send a command and await its response.
+    #[hotpath::measure]
     pub fn send<T: Command>(
         &self,
         cmd: T,
         session_id: Option<&SessionId>,
     ) -> Result<T::Response> {
-        self.inner.send(cmd, session_id)
+        self.request(cmd, session_id)?.wait()
+    }
+
+    /// Submit a command without waiting for its response.
+    ///
+    /// The five-second response deadline starts at submission. Submit independent
+    /// commands before calling [`PendingResponse::wait`] to overlap their waits.
+    /// Submission may block on the bounded worker queue, within that deadline.
+    pub fn request<T: Command>(
+        &self,
+        cmd: T,
+        session_id: Option<&SessionId>,
+    ) -> Result<PendingResponse<T>> {
+        self.inner.request(cmd, session_id)
     }
 
     /// Post a command without awaiting its response.
@@ -70,6 +87,53 @@ impl Connection {
         self.inner.close()
     }
 }
+
+/// A submitted command's typed response. Waiting consumes the handle.
+///
+/// Dropping this handle discards the response; it does not cancel the command.
+/// Keep the connection alive until the outstanding responses have been collected.
+#[derive(Debug)]
+#[must_use = "wait for the response, or explicitly drop it to discard the result"]
+pub struct PendingResponse<T: Command> {
+    call_id: CallId,
+    method: MethodId,
+    deadline: Instant,
+    reply_rx: mpmc::Receiver<Reply>,
+    command: PhantomData<fn() -> T>,
+}
+
+impl<T: Command> PendingResponse<T> {
+    /// Wait until the original submission deadline, then decode the response.
+    /// A response received before the deadline can be collected after it expires.
+    #[hotpath::measure]
+    pub fn wait(self) -> Result<T::Response> {
+        let (received_at, result) = match self
+            .reply_rx
+            .recv_deadline(self.deadline)
+        {
+            Ok(reply) => reply,
+            Err(mpmc::RecvTimeoutError::Timeout) => {
+                bail!("timed out waiting for response for {}", self.method);
+            }
+            Err(mpmc::RecvTimeoutError::Disconnected) => {
+                bail!(
+                    "channel disconnected while waiting for response for {}",
+                    self.method
+                );
+            }
+        };
+        if received_at > self.deadline {
+            bail!("timed out waiting for response for {}", self.method);
+        }
+        let value = result
+            .with_context(|| format!("send failed for {}", self.method))?;
+        log::debug!("got response for {} ({})", self.method, self.call_id);
+        T::response_from_value(value)
+            .with_context(|| format!("decoding response for {}", self.method))
+    }
+}
+
+type Reply = (Instant, Result<json::Value>);
 
 #[derive(Debug)]
 struct ConnectionInner {
@@ -171,79 +235,44 @@ impl ConnectionInner {
     }
 
     #[hotpath::measure]
-    pub(crate) fn send<T: Command>(
+    fn request<T: Command>(
         &self,
         cmd: T,
         session_id: Option<&SessionId>,
-    ) -> Result<T::Response> {
+    ) -> Result<PendingResponse<T>> {
+        let deadline = Instant::now() + Duration::from_secs(5);
         let call_id = self.next_call_id();
+        let method = cmd.identifier();
         log::debug!(
             "sending {} ({}), session={:?}",
-            cmd.identifier(),
+            method,
             call_id,
             session_id
         );
-
         let call = MethodCall {
             id: call_id,
-            method: cmd.identifier(),
+            method: method.clone(),
             session_id: session_id.map(|id| id.inner().into()),
             params: serde_json::to_value(&cmd)?,
         };
         let (reply_tx, reply_rx) = mpmc::bounded(1);
         self.worker_tx
-            .send(WorkerRequest::Send {
-                call,
-                reply_tx: Some(reply_tx),
-            })
-            .context(format!("send failed for {}", cmd.identifier()))?;
+            .send_deadline(
+                WorkerRequest::Send {
+                    call,
+                    reply_tx: Some(reply_tx),
+                },
+                deadline,
+            )
+            .with_context(|| format!("send failed for {method}"))?;
         self.commands_waker.wake()?;
-
-        let result = match reply_rx.recv_timeout(Duration::from_secs(5)) {
-            Ok(result) => {
-                result.context(format!("send failed for {}", cmd.identifier()))
-            }
-            Err(mpmc::RecvTimeoutError::Timeout) => {
-                log::debug!(
-                    "timed out waiting for response for {}",
-                    cmd.identifier()
-                );
-                bail!(
-                    "timed out waiting for response for {}",
-                    cmd.identifier(),
-                );
-            }
-            Err(mpmc::RecvTimeoutError::Disconnected) => {
-                log::debug!(
-                    "channel disconnected while waiting for response for {}",
-                    cmd.identifier()
-                );
-                bail!(
-                    "channel disconnected while waiting for response for {}",
-                    cmd.identifier(),
-                )
-            }
-        };
-
-        match result {
-            Ok(value) => {
-                log::debug!(
-                    "got response for {} ({})",
-                    cmd.identifier(),
-                    call_id,
-                );
-                Ok(T::response_from_value(value)?)
-            }
-            Err(err) => {
-                log::debug!(
-                    "got error for {} ({}): {}",
-                    cmd.identifier(),
-                    call_id,
-                    err
-                );
-                Err(err)
-            }
-        }
+        Ok(PendingResponse {
+            call_id,
+            method,
+            deadline,
+            reply_rx,
+            command: PhantomData,
+        })
     }
 
     pub(crate) fn close(&self) -> Result<()> {
@@ -294,12 +323,12 @@ fn supervise_worker(
 enum WorkerRequest {
     Send {
         call: MethodCall,
-        reply_tx: Option<mpmc::Sender<Result<json::Value>>>,
+        reply_tx: Option<mpmc::Sender<Reply>>,
     },
     Close,
 }
 
-type CallsInFlight = HashMap<CallId, Option<mpmc::Sender<Result<json::Value>>>>;
+type CallsInFlight = HashMap<CallId, Option<mpmc::Sender<Reply>>>;
 
 enum DrainResult {
     Continue,
@@ -314,19 +343,14 @@ fn calls_drain(
     loop {
         match requests_rx.try_recv() {
             Ok(WorkerRequest::Send { call, reply_tx }) => {
-                let reply_error =
-                    |reply_tx: &Option<mpmc::Sender<Result<json::Value>>>,
-                     error| {
-                        if let Some(tx) = reply_tx {
-                            if let Err(error) = tx.send(Err(error)) {
-                                log::error!(
-                                    "failed sending command error: {error:#}"
-                                );
-                            }
-                        } else {
-                            log::error!("posted command failed: {error:#}");
-                        }
-                    };
+                let reply_error = |reply_tx: &Option<mpmc::Sender<Reply>>,
+                                   error| {
+                    if let Some(tx) = reply_tx {
+                        let _ = tx.send((Instant::now(), Err(error)));
+                    } else {
+                        log::error!("posted command failed: {error:#}");
+                    }
+                };
 
                 if calls_in_flight.contains_key(&call.id) {
                     reply_error(
@@ -469,15 +493,16 @@ fn handle_message(
                     );
                 }
                 if let Some(reply_tx) = calls_in_flight.remove(&response.id) {
-                    // There's only a reply_tx if it was a `send`, not for `post`.
+                    // Requests expect a response; posts discard it.
                     if let Some(reply_tx) = reply_tx {
                         if let Some(err) = response.error {
-                            let _ = reply_tx.send(Err(err.into()));
+                            let _ = reply_tx
+                                .send((Instant::now(), Err(err.into())));
                         } else {
                             let result = response
                                 .result
                                 .unwrap_or(serde_json::Value::Null);
-                            let _ = reply_tx.send(Ok(result));
+                            let _ = reply_tx.send((Instant::now(), Ok(result)));
                         }
                     } else {
                         if response.error.is_none() {
@@ -645,7 +670,7 @@ fn websocket_worker(
 mod tests {
     use std::borrow::Cow;
     use std::net::TcpListener;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use serde::{Deserialize, Serialize};
 
@@ -715,6 +740,184 @@ mod tests {
             }
         });
         (format!("ws://{address}"), handle)
+    }
+
+    fn scripted_server(
+        script: impl FnOnce(&mut WebSocket<TcpStream>) + Send + 'static,
+    ) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .unwrap();
+            let mut ws = tungstenite::accept(stream).unwrap();
+            script(&mut ws);
+            while let Ok(message) = ws.read() {
+                if matches!(message, WsMessage::Close(_)) {
+                    break;
+                }
+            }
+        });
+        (format!("ws://{address}"), server)
+    }
+
+    fn read_command(ws: &mut WebSocket<TcpStream>) -> json::Value {
+        let message = ws.read().unwrap();
+        json::from_str(message.to_text().unwrap()).unwrap()
+    }
+
+    fn respond(
+        ws: &mut WebSocket<TcpStream>,
+        command: &json::Value,
+        result: json::Value,
+    ) {
+        ws.send(WsMessage::text(
+            json::json!({"id": command["id"], "result": result}).to_string(),
+        ))
+        .unwrap();
+    }
+
+    fn test_command() -> TestCommand {
+        TestCommand {
+            payload: "small".into(),
+        }
+    }
+
+    #[derive(Debug, Serialize)]
+    struct NumberCommand {}
+
+    impl Method for NumberCommand {
+        fn identifier(&self) -> MethodId {
+            Cow::Borrowed("Test.number")
+        }
+    }
+
+    impl Command for NumberCommand {
+        type Response = u64;
+    }
+
+    #[test]
+    fn pending_requests_route_out_of_order_heterogeneous_responses() {
+        let (url, server) = scripted_server(|ws| {
+            // No response is sent until all requests arrive. A serialized
+            // implementation cannot make progress through this barrier.
+            let first = read_command(ws);
+            let second = read_command(ws);
+            assert_eq!(first["method"], "Test.command");
+            assert_eq!(second["method"], "Test.number");
+            assert_eq!(first["sessionId"], "test-session");
+            assert_eq!(second["sessionId"], "test-session");
+            respond(ws, &second, json::json!(42));
+            respond(ws, &first, json::json!({"received": true}));
+        });
+        let connection = Connection::connect(url).unwrap();
+        let session = SessionId::from("test-session".to_owned());
+        let first = connection.request(test_command(), Some(&session)).unwrap();
+        let second = connection
+            .request(NumberCommand {}, Some(&session))
+            .unwrap();
+        let responses = (first.wait().unwrap(), second.wait().unwrap());
+        assert_eq!(responses, (TestResponse { received: true }, 42));
+        connection.close().unwrap();
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn dropped_and_failed_requests_do_not_disrupt_other_responses() {
+        let (url, server) =
+            scripted_server(|ws| {
+                let dropped = read_command(ws);
+                let failed = read_command(ws);
+                let survivor = read_command(ws);
+                respond(ws, &dropped, json::json!({"received": true}));
+                ws.send(WsMessage::text(json::json!({
+                "id": failed["id"],
+                "error": {"code": -32000, "message": "injected failure"},
+            }).to_string())).unwrap();
+                respond(ws, &survivor, json::json!(42));
+                let subsequent = read_command(ws);
+                respond(ws, &subsequent, json::json!({"received": true}));
+            });
+        let connection = Connection::connect(url).unwrap();
+        drop(connection.request(test_command(), None).unwrap());
+        let failed = connection.request(test_command(), None).unwrap();
+        let survivor = connection.request(NumberCommand {}, None).unwrap();
+        let error = format!("{:#}", failed.wait().unwrap_err());
+        assert!(error.contains("Test.command"));
+        assert!(error.contains("injected failure"));
+        assert_eq!(survivor.wait().unwrap(), 42);
+        assert_eq!(
+            connection.send(test_command(), None).unwrap(),
+            TestResponse { received: true }
+        );
+        connection.close().unwrap();
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn response_deadlines_start_at_submission_not_collection() {
+        let (release_tx, release_rx) = mpmc::bounded(1);
+        let (url, server) = scripted_server(move |ws| {
+            let early = read_command(ws);
+            let late = read_command(ws);
+            let _unanswered = read_command(ws);
+            respond(ws, &early, json::json!({"received": true}));
+            let barrier = read_command(ws);
+            respond(ws, &barrier, json::json!(1));
+            release_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+            respond(ws, &late, json::json!({"received": true}));
+            let barrier = read_command(ws);
+            respond(ws, &barrier, json::json!(2));
+        });
+        let connection = Connection::connect(url).unwrap();
+        let early = connection.request(test_command(), None).unwrap();
+        let late = connection.request(test_command(), None).unwrap();
+        let unanswered = connection.request(test_command(), None).unwrap();
+        // Receiving this response proves the worker delivered the early reply.
+        assert_eq!(connection.send(NumberCommand {}, None).unwrap(), 1);
+        thread::sleep(Duration::from_millis(5100));
+        release_tx.send(()).unwrap();
+        // Likewise, ensure the late reply is queued before collecting it.
+        assert_eq!(connection.send(NumberCommand {}, None).unwrap(), 2);
+        assert_eq!(early.wait().unwrap(), TestResponse { received: true });
+        let start = Instant::now();
+        assert!(late.wait().unwrap_err().to_string().contains("timed out"));
+        assert!(
+            unanswered
+                .wait()
+                .unwrap_err()
+                .to_string()
+                .contains("timed out")
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "wait restarted the timeout"
+        );
+        connection.close().unwrap();
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn closing_connection_wakes_pending_responses() {
+        let (received_tx, received_rx) = mpmc::bounded(1);
+        let (url, server) = scripted_server(move |ws| {
+            read_command(ws);
+            received_tx.send(()).unwrap();
+        });
+        let connection = Connection::connect(url).unwrap();
+        let pending = connection.request(test_command(), None).unwrap();
+        received_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        connection.close().unwrap();
+        assert!(
+            pending
+                .wait()
+                .unwrap_err()
+                .to_string()
+                .contains("disconnected")
+        );
+        server.join().unwrap();
     }
 
     #[test]

--- a/lib/cdp/src/conn.rs
+++ b/lib/cdp/src/conn.rs
@@ -944,7 +944,6 @@ mod tests {
             Cow::Borrowed("Test.second"),
             Cow::Borrowed("Test.first"),
         ]);
-        let all = events.all();
         let mut calls = HashMap::new();
         for method in ["Test.first", "Test.ignored", "Test.second"] {
             handle_message(
@@ -955,7 +954,6 @@ mod tests {
                 &subscribers,
             ).unwrap();
         }
-        assert_eq!(all.len(), 3);
         assert_eq!(selected.len(), 2);
         for method in ["Test.first", "Test.second"] {
             let event = selected.recv().unwrap();

--- a/lib/cdp/src/conn.rs
+++ b/lib/cdp/src/conn.rs
@@ -100,7 +100,7 @@ pub struct PendingResponse<T: Command> {
     method: MethodId,
     deadline: Instant,
     reply_rx: mpmc::Receiver<Reply>,
-    command: PhantomData<fn() -> T>,
+    command: PhantomData<T>,
 }
 
 impl<T: Command> PendingResponse<T> {

--- a/lib/cdp/src/conn.rs
+++ b/lib/cdp/src/conn.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::marker::PhantomData;
 use std::net::TcpStream;
+use std::ops::Range;
 use std::os::fd::{AsRawFd, RawFd};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -15,14 +17,13 @@ use mio::{Events as MioEvents, Interest, Poll, Token, Waker};
 use tungstenite::client::{IntoClientRequest, connect_with_config};
 use tungstenite::protocol::WebSocketConfig;
 use tungstenite::stream::MaybeTlsStream;
-use tungstenite::{Message as WsMessage, WebSocket};
+use tungstenite::{Message as WsMessage, Utf8Bytes, WebSocket};
 
-use cdp_types::{
-    CallId, CdpJsonEventMessage, Command, MethodCall, MethodId, Response,
-};
+use cdp_types::{CallId, CdpJsonEventMessage, Command, MethodCall, MethodId};
 use serde::Deserialize;
-use serde::de::IgnoredAny;
+#[cfg(test)]
 use serde_json as json;
+use serde_json::value::RawValue;
 
 use anyhow::{Context, anyhow, bail};
 
@@ -128,12 +129,48 @@ impl<T: Command> PendingResponse<T> {
         let value = result
             .with_context(|| format!("send failed for {}", self.method))?;
         log::debug!("got response for {} ({})", self.method, self.call_id);
-        T::response_from_value(value)
+        serde_json::from_str(value.get())
             .with_context(|| format!("decoding response for {}", self.method))
     }
 }
 
-type Reply = (Instant, Result<json::Value>);
+type Reply = (Instant, Result<ResponsePayload>);
+
+/// Keep the received buffer alive until the caller decodes its result.
+#[derive(Debug)]
+struct ResponsePayload {
+    text: Utf8Bytes,
+    range: Range<usize>,
+}
+
+impl ResponsePayload {
+    // Locate the borrowed payload before moving its backing frame into the reply.
+    fn range_in_frame(
+        text: &str,
+        result: Option<&RawValue>,
+    ) -> Option<Range<usize>> {
+        result.map(|result| {
+            // Borrowed RawValue is a subslice of this frame, so these are
+            // UTF-8 byte offsets, including any original JSON escapes.
+            let start = result.get().as_ptr() as usize - text.as_ptr() as usize;
+            start..start + result.get().len()
+        })
+    }
+
+    fn from_frame(text: Utf8Bytes, range: Option<Range<usize>>) -> Self {
+        match range {
+            Some(range) => Self { text, range },
+            None => Self {
+                text: Utf8Bytes::from_static("null"),
+                range: 0..4,
+            },
+        }
+    }
+
+    fn get(&self) -> &str {
+        &self.text.as_str()[self.range.clone()]
+    }
+}
 
 #[derive(Debug)]
 struct ConnectionInner {
@@ -467,61 +504,86 @@ fn handle_message(
     match msg {
         WsMessage::Text(text) => {
             let text_str = text.as_str();
-            // We only parse `Message` when we know that there's no `id` field, and otherwise
-            // parse as `Response`. Hence, we need do a first parsing pass with this cheap struct.
+            // Borrow payloads until routing decides whether a consumer needs them.
+            // RawValue validates JSON without allocating a Value tree.
             #[derive(Deserialize)]
-            struct Peek {
-                #[serde(default)]
-                id: Option<IgnoredAny>,
+            struct Envelope<'a> {
+                id: Option<CallId>,
+                #[serde(default, borrow)]
+                method: Cow<'a, str>,
+                #[serde(borrow)]
+                result: Option<&'a RawValue>,
+                error: Option<cdp_types::Error>,
             }
-            let peek: Peek = serde_json::from_str(text_str).map_err(|err| {
-                anyhow!("failed to parse ws text frame '{}': {err}", text_str)
-            })?;
-            if peek.id.is_some() {
-                let response: Response = serde_json::from_str(text_str)
-                    .map_err(|err| {
-                        anyhow!(
-                            "failed to parse response '{}': {err}",
-                            text_str
-                        )
-                    })?;
+            let response: Envelope<'_> = serde_json::from_str(text_str)
+                .map_err(|err| {
+                    anyhow!(
+                        "failed to parse ws text frame '{}': {err}",
+                        text_str
+                    )
+                })?;
+            if let Some(id) = response.id {
                 if let Some(error) = &response.error {
                     log::debug!(
                         "received command error from websocket: call={}, error={}",
-                        response.id,
+                        id,
                         error,
                     );
                 }
-                if let Some(reply_tx) = calls_in_flight.remove(&response.id) {
+                if let Some(reply_tx) = calls_in_flight.remove(&id) {
                     // Requests expect a response; posts discard it.
                     if let Some(reply_tx) = reply_tx {
                         if let Some(err) = response.error {
                             let _ = reply_tx
                                 .send((Instant::now(), Err(err.into())));
                         } else {
-                            let result = response
-                                .result
-                                .unwrap_or(serde_json::Value::Null);
+                            let range = ResponsePayload::range_in_frame(
+                                text_str,
+                                response.result,
+                            );
+                            let result =
+                                ResponsePayload::from_frame(text, range);
                             let _ = reply_tx.send((Instant::now(), Ok(result)));
                         }
-                    } else {
-                        if response.error.is_none() {
-                            log::debug!(
-                                "received response for post {}: exception_details={:?}",
-                                response.id,
-                                response.result.as_ref().and_then(|result| {
-                                    result.get("exceptionDetails")
-                                }),
-                            );
+                    } else if response.error.is_none()
+                        && log::log_enabled!(log::Level::Debug)
+                    {
+                        #[derive(Deserialize)]
+                        struct PostResult<'a> {
+                            #[serde(rename = "exceptionDetails", borrow)]
+                            exception_details: Option<&'a RawValue>,
                         }
+                        let exception_details =
+                            response.result.and_then(|result| {
+                                serde_json::from_str::<PostResult<'_>>(
+                                    result.get(),
+                                )
+                                .ok()
+                                .and_then(|result| result.exception_details)
+                            });
+                        log::debug!(
+                            "received response for post {}: exception_details={:?}",
+                            id,
+                            exception_details.map(RawValue::get),
+                        );
                     }
                 } else {
                     bail!(
                         "got unexpected response ({}) with no corresponding request in flight",
-                        response.id
+                        id
                     );
                 }
             } else {
+                let method = response.method.as_ref();
+                if method.is_empty() {
+                    bail!("event is missing its method");
+                }
+                let mut subscribers = subscribers.lock().map_err(|_| {
+                    anyhow!("failed to acquire lock for subscribers")
+                })?;
+                if !subscribers.is_interested_in(method) {
+                    return Ok(());
+                }
                 let event: CdpJsonEventMessage = serde_json::from_str(text_str)
                     .map_err(|err| {
                         anyhow!("failed to parse event '{}': {err}", text_str)
@@ -563,12 +625,7 @@ fn handle_message(
                         event.params.get(),
                     );
                 }
-                let mut subscribers = subscribers.lock().map_err(|_| {
-                    anyhow!("failed to acquire lock for subscribers")
-                })?;
-                if !subscribers.closed {
-                    subscribers.dispatch(event);
-                }
+                subscribers.dispatch(event);
             }
         }
         // Tungstenite queues Pong replies automatically while reading.
@@ -796,6 +853,144 @@ mod tests {
 
     impl Command for NumberCommand {
         type Response = u64;
+    }
+
+    #[test]
+    fn response_payload_stays_raw_until_typed_wait() {
+        let subscribers = Arc::new(Mutex::new(Subscribers::default()));
+        let (tx, rx) = mpmc::bounded(1);
+        let id = CallId::new(7);
+        let mut calls = HashMap::from([(id, Some(tx))]);
+        // This unused number cannot be represented by Value, but typed decoding
+        // can skip it. Preserve the original payload through the worker queue.
+        let payload = r#"{ "received": true, "unused": 1e999 }"#;
+        let text = format!(r#"{{"result":{payload},"id":7}}"#);
+        let payload_ptr = text[10..].as_ptr();
+        handle_message(WsMessage::text(text), &mut calls, &subscribers)
+            .unwrap();
+        assert!(calls.is_empty());
+        let reply = rx.recv().unwrap();
+        assert_eq!(reply.1.as_ref().unwrap().get(), payload);
+        assert_eq!(reply.1.as_ref().unwrap().get().as_ptr(), payload_ptr);
+        let (tx, rx) = mpmc::bounded(1);
+        tx.send(reply).unwrap();
+        let pending = PendingResponse::<TestCommand> {
+            call_id: id,
+            method: Cow::Borrowed("Test.command"),
+            deadline: Instant::now() + Duration::from_secs(1),
+            reply_rx: rx,
+            command: PhantomData,
+        };
+        assert_eq!(pending.wait().unwrap(), TestResponse { received: true });
+    }
+
+    #[test]
+    fn response_ranges_preserve_unicode_escapes_and_null_defaults() {
+        let subscribers = Arc::new(Mutex::new(Subscribers::default()));
+        for (text, expected) in [
+            (
+                r#"{"sessionId":"ø","id":7,"result":{"data":"é\n\""}}"#,
+                r#"{"data":"é\n\""}"#,
+            ),
+            (r#"{"result":"é","id":7}"#, r#""é""#),
+            (r#"{"id":7,"result":null}"#, "null"),
+            (r#"{"id":7}"#, "null"),
+        ] {
+            let (tx, rx) = mpmc::bounded(1);
+            let mut calls = HashMap::from([(CallId::new(7), Some(tx))]);
+            handle_message(WsMessage::text(text), &mut calls, &subscribers)
+                .unwrap();
+            let response = rx.recv().unwrap().1.unwrap();
+            assert_eq!(response.get(), expected);
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(response.get())
+                    .unwrap(),
+                serde_json::from_str::<serde_json::Value>(expected).unwrap(),
+            );
+        }
+    }
+
+    #[test]
+    fn post_response_skips_unused_payload() {
+        let subscribers = Arc::new(Mutex::new(Subscribers::default()));
+        let mut calls = HashMap::from([(CallId::new(7), None)]);
+        handle_message(
+            WsMessage::text(r#"{"result":{"unused":1e999},"id":7}"#),
+            &mut calls,
+            &subscribers,
+        )
+        .unwrap();
+        assert!(calls.is_empty());
+        assert!(
+            handle_message(
+                WsMessage::text(r#"{"result":{},"id":8}"#),
+                &mut calls,
+                &subscribers,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("no corresponding request")
+        );
+    }
+
+    #[test]
+    fn selected_events_keep_order_session_and_raw_params() {
+        let subscribers = Arc::new(Mutex::new(Subscribers::default()));
+        let events = Events {
+            subscribers: subscribers.clone(),
+        };
+        let selected = events.methods([
+            Cow::Borrowed("Test.first"),
+            Cow::Borrowed("Test.second"),
+            Cow::Borrowed("Test.first"),
+        ]);
+        let all = events.all();
+        let mut calls = HashMap::new();
+        for method in ["Test.first", "Test.ignored", "Test.second"] {
+            handle_message(
+                WsMessage::text(format!(
+                    r#"{{"params":{{"unused":1e999}},"sessionId":"session","method":"{method}"}}"#
+                )),
+                &mut calls,
+                &subscribers,
+            ).unwrap();
+        }
+        assert_eq!(all.len(), 3);
+        assert_eq!(selected.len(), 2);
+        for method in ["Test.first", "Test.second"] {
+            let event = selected.recv().unwrap();
+            assert_eq!(event.method, method);
+            assert_eq!(event.session_id.as_deref(), Some("session"));
+            assert_eq!(event.params.get(), r#"{"unused":1e999}"#);
+        }
+        events.close();
+        assert!(matches!(
+            selected.try_recv(),
+            Err(mpmc::TryRecvError::Disconnected)
+        ));
+    }
+
+    #[test]
+    fn uninterested_events_skip_payload_decoding() {
+        let subscribers = Arc::new(Mutex::new(Subscribers::default()));
+        let mut calls = HashMap::new();
+        // The envelope is valid JSON but has no typed event payload.
+        handle_message(
+            WsMessage::text(r#"{"method":"Test.ignored"}"#),
+            &mut calls,
+            &subscribers,
+        )
+        .unwrap();
+        assert!(
+            handle_message(
+                WsMessage::text(
+                    r#"{"method":"Test.ignored","params":invalid}"#
+                ),
+                &mut calls,
+                &subscribers,
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/lib/cdp/src/events.rs
+++ b/lib/cdp/src/events.rs
@@ -18,14 +18,12 @@ pub struct Events {
 pub(crate) struct Subscribers {
     closed: bool,
     close_error: Option<String>,
-    all: Vec<mpmc::Sender<Arc<CdpJsonEventMessage>>>,
     single: HashMap<MethodId, Vec<mpmc::Sender<Arc<CdpJsonEventMessage>>>>,
 }
 
 impl Subscribers {
     pub(crate) fn is_interested_in(&self, method: &str) -> bool {
-        !self.closed
-            && (!self.all.is_empty() || self.single.contains_key(method))
+        !self.closed && self.single.contains_key(method)
     }
 
     #[hotpath::measure]
@@ -35,7 +33,6 @@ impl Subscribers {
 
         // These channels are unbounded, so a slow subscriber cannot block the
         // WebSocket worker that must read command responses.
-        self.all.retain(|s| s.send(event.clone()).is_ok());
         if let Some(subscriptions) = self.single.get_mut(&event.method) {
             subscriptions.retain(|s| s.send(event.clone()).is_ok());
             if subscriptions.is_empty() {
@@ -50,24 +47,11 @@ impl Subscribers {
         }
         self.closed = true;
         self.close_error = error;
-        self.all.clear();
         self.single.clear();
     }
 }
 
 impl Events {
-    pub fn all(&self) -> mpmc::Receiver<Arc<CdpJsonEventMessage>> {
-        let mut subscribers = self
-            .subscribers
-            .lock()
-            .expect("failed to acquire lock for subscribers");
-        let (tx, rx) = mpmc::unbounded();
-        if !subscribers.closed {
-            subscribers.all.push(tx);
-        }
-        rx
-    }
-
     /// Receive only the selected methods, preserving their arrival order.
     pub fn methods(
         &self,
@@ -199,7 +183,7 @@ mod tests {
         let events = Events {
             subscribers: subscribers.clone(),
         };
-        let receiver = events.all();
+        let receiver = events.methods([TestEvent::method_id()]);
         let (done_tx, done_rx) = mpmc::bounded(1);
 
         std::thread::spawn(move || {
@@ -243,7 +227,7 @@ mod tests {
             .unwrap()
             .close(Some("worker failed".into()));
         assert!(matches!(
-            events.all().try_recv(),
+            events.methods([TestEvent::method_id()]).try_recv(),
             Err(mpmc::TryRecvError::Disconnected)
         ));
         assert_eq!(

--- a/lib/cdp/src/events.rs
+++ b/lib/cdp/src/events.rs
@@ -16,14 +16,18 @@ pub struct Events {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Subscribers {
-    pub(crate) closed: bool,
-    pub(crate) close_error: Option<String>,
-    pub(crate) all: Vec<mpmc::Sender<Arc<CdpJsonEventMessage>>>,
-    pub(crate) single:
-        HashMap<MethodId, Vec<mpmc::Sender<Arc<CdpJsonEventMessage>>>>,
+    closed: bool,
+    close_error: Option<String>,
+    all: Vec<mpmc::Sender<Arc<CdpJsonEventMessage>>>,
+    single: HashMap<MethodId, Vec<mpmc::Sender<Arc<CdpJsonEventMessage>>>>,
 }
 
 impl Subscribers {
+    pub(crate) fn is_interested_in(&self, method: &str) -> bool {
+        !self.closed
+            && (!self.all.is_empty() || self.single.contains_key(method))
+    }
+
     #[hotpath::measure]
     pub(crate) fn dispatch(&mut self, event: CdpJsonEventMessage) {
         assert!(!self.closed, "Subscribers are closed, can't dispatch");
@@ -60,6 +64,31 @@ impl Events {
         let (tx, rx) = mpmc::unbounded();
         if !subscribers.closed {
             subscribers.all.push(tx);
+        }
+        rx
+    }
+
+    /// Receive only the selected methods, preserving their arrival order.
+    pub fn methods(
+        &self,
+        methods: impl IntoIterator<Item = MethodId>,
+    ) -> mpmc::Receiver<Arc<CdpJsonEventMessage>> {
+        let mut subscribers = self
+            .subscribers
+            .lock()
+            .expect("failed to acquire lock for subscribers");
+        let (tx, rx) = mpmc::unbounded();
+        if !subscribers.closed {
+            let mut unique = std::collections::HashSet::new();
+            for method in methods {
+                if unique.insert(method.clone()) {
+                    subscribers
+                        .single
+                        .entry(method)
+                        .or_default()
+                        .push(tx.clone());
+                }
+            }
         }
         rx
     }

--- a/lib/cdp/src/lib.rs
+++ b/lib/cdp/src/lib.rs
@@ -3,7 +3,7 @@
 pub use cdp_protocol;
 pub use cdp_types::{self as types, Binary, Command, Method, MethodType};
 
-pub use crate::conn::Connection;
+pub use crate::conn::{Connection, PendingResponse};
 pub use crate::error::{CdpError, Result};
 pub use crate::events::{Events, Subscriber};
 

--- a/lib/cdp/types/src/lib.rs
+++ b/lib/cdp/types/src/lib.rs
@@ -47,13 +47,6 @@ impl CallId {
 pub trait Command: serde::ser::Serialize + Method {
     /// The type of the response this request triggers on the chromium server
     type Response: serde::de::DeserializeOwned + fmt::Debug;
-
-    /// deserialize the response from json
-    fn response_from_value(
-        response: serde_json::Value,
-    ) -> serde_json::Result<Self::Response> {
-        serde_json::from_value(response)
-    }
 }
 
 /// A generic, successful,  response of a request where the `result` has been


### PR DESCRIPTION
TL;DR: 
All in all we spend less time doing `state::current` work, as well as improving overall mem footprints. Going from 631.1 MB -> 527.3 MB. 
This will probably be a bigger benefit for longer fuzz runs.  

Before:
<img width="1830" height="2384" alt="54283" src="https://github.com/user-attachments/assets/2dddb717-4a6a-46f1-99fb-2cbf5462d380" />



After fff8907:

<img width="1940" height="2506" alt="40451" src="https://github.com/user-attachments/assets/cef6daac-ba95-4b50-a4bb-a610cbdd2aa3" />
