### PR TITLE
fix: add test and fix for action races

### DIFF
--- a/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
+++ b/lib/bombadil-browser-integration-tests/tests/integration_tests.rs
@@ -544,6 +544,66 @@ export const counterStateMachine = always(unchanged.or(increment).or(decrement))
 }
 
 #[test]
+fn test_scroll_settles_before_next_state() {
+    BrowserIntegrationTest::new("scroll-race")
+        .time_limit(Duration::from_secs(2))
+        .specification(
+            r#"
+import { now, next, always } from "@antithesishq/bombadil";
+import { actions, extract } from "@antithesishq/bombadil/browser";
+import { lastAction } from "@antithesishq/bombadil/browser/defaults/actions";
+
+const scrollY = extract((state) => state.window.scrollY);
+const innerHeight = extract((state) => state.window.innerHeight);
+const maxScrollY = extract(
+  (state) =>
+    (state.document.body?.scrollHeight ?? 0) - state.window.innerHeight,
+);
+
+// Only scroll down; wait once we've reached the bottom so the runner keeps
+// evaluating the property until the time limit fires.
+export const scrollDown = actions(() => {
+  const remaining = maxScrollY.current - scrollY.current;
+  if (remaining < 1) return ["Wait"];
+  return [
+    {
+      ScrollDown: {
+        origin: { x: 400, y: innerHeight.current / 2 },
+        distance: Math.min(innerHeight.current / 2, remaining),
+      },
+    },
+  ];
+});
+
+// If the last action was a scroll, window.scrollY in the state that follows
+// must be offset from the previous scrollY by exactly the scroll distance.
+// If state is captured before the synthesized scroll gesture has finished,
+// this property observes a partial scroll and fails.
+//
+// TODO: this should ideally be defined using an `until` operator when that
+// is implemented, where the stop condition is "at end of document".
+export const scrollSettlesBeforeNextState = always(() => {
+  const previous = scrollY.current;
+  return next(() => {
+    const action = lastAction.current;
+    if (!action || typeof action !== "object") return true;
+    let expected;
+    if ("ScrollDown" in action) {
+      expected = previous + action.ScrollDown.distance;
+    } else if ("ScrollUp" in action) {
+      expected = previous - action.ScrollUp.distance;
+    } else {
+      return true;
+    }
+    return Math.abs(scrollY.current - expected) < 2;
+  });
+});
+"#,
+        )
+        .run();
+}
+
+#[test]
 fn test_resource_leak_detected() {
     BrowserIntegrationTest::new("resource-leak")
         .time_limit(Duration::from_secs(8))

--- a/lib/bombadil-browser-integration-tests/tests/scroll-race/index.html
+++ b/lib/bombadil-browser-integration-tests/tests/scroll-race/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Scroll race</title>
+    <style>
+      body { margin: 0; }
+      .filler {
+        height: 500px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: sans-serif;
+        font-size: 48px;
+      }
+      .filler:nth-child(odd)  { background: #eef; }
+      .filler:nth-child(even) { background: #fee; }
+    </style>
+  </head>
+  <body>
+    <div class="filler">1</div>
+    <div class="filler">2</div>
+    <div class="filler">3</div>
+  </body>
+</html>

--- a/lib/bombadil-browser/src/browser/actions.rs
+++ b/lib/bombadil-browser/src/browser/actions.rs
@@ -109,7 +109,7 @@ impl BrowserAction {
                 let last: page::NavigationEntry = history.entries
                     [(history.current_index - 1) as usize]
                     .clone();
-                connection.post(
+                connection.send(
                     page::NavigateToHistoryEntryParams::builder()
                         .entry_id(last.id)
                         .build()
@@ -128,7 +128,7 @@ impl BrowserAction {
                 }
                 let next: page::NavigationEntry =
                     history.entries[next_index].clone();
-                connection.post(
+                connection.send(
                     page::NavigateToHistoryEntryParams::builder()
                         .entry_id(next.id)
                         .build()
@@ -142,7 +142,7 @@ impl BrowserAction {
             }
             BrowserAction::Wait => {}
             BrowserAction::ScrollUp { origin, distance } => {
-                connection.post(
+                connection.send(
                     input::SynthesizeScrollGestureParams::builder()
                         .x(origin.x)
                         .y(origin.y)
@@ -154,7 +154,7 @@ impl BrowserAction {
                 )?;
             }
             BrowserAction::ScrollDown { origin, distance } => {
-                connection.post(
+                connection.send(
                     input::SynthesizeScrollGestureParams::builder()
                         .x(origin.x)
                         .y(origin.y)
@@ -171,7 +171,7 @@ impl BrowserAction {
                     .y(point.y)
                     .button(input::MouseButton::Left)
                     .click_count(1);
-                connection.post(
+                connection.send(
                     input::DispatchMouseEventParams::new(
                         input::DispatchMouseEventType::MouseMoved,
                         point.x,
@@ -179,7 +179,7 @@ impl BrowserAction {
                     ),
                     Some(session_id),
                 )?;
-                connection.post(
+                connection.send(
                     builder
                         .clone()
                         .r#type(input::DispatchMouseEventType::MousePressed)
@@ -187,7 +187,7 @@ impl BrowserAction {
                         .map_err(|err| anyhow!(err))?,
                     Some(session_id),
                 )?;
-                connection.post(
+                connection.send(
                     builder
                         .r#type(input::DispatchMouseEventType::MouseReleased)
                         .build()
@@ -212,7 +212,7 @@ impl BrowserAction {
                     ),
                     Some(session_id),
                 )?;
-                connection.post(
+                connection.send(
                     builder
                         .clone()
                         .r#type(input::DispatchMouseEventType::MousePressed)
@@ -220,7 +220,7 @@ impl BrowserAction {
                         .map_err(|err| anyhow!(err))?,
                     Some(session_id),
                 )?;
-                connection.post(
+                connection.send(
                     builder
                         .r#type(input::DispatchMouseEventType::MouseReleased)
                         .build()
@@ -255,7 +255,7 @@ impl BrowserAction {
                     }
                     builder.build().map_err(|err| anyhow!(err))
                 };
-                connection.post(
+                connection.send(
                     build_params(
                         input::DispatchKeyEventType::RawKeyDown,
                         None,
@@ -263,7 +263,7 @@ impl BrowserAction {
                     Some(session_id),
                 )?;
                 if let Some(text) = text {
-                    connection.post(
+                    connection.send(
                         build_params(
                             input::DispatchKeyEventType::Char,
                             Some(text),
@@ -271,7 +271,7 @@ impl BrowserAction {
                         Some(session_id),
                     )?;
                 }
-                connection.post(
+                connection.send(
                     build_params(input::DispatchKeyEventType::KeyUp, None)?,
                     Some(session_id),
                 )?;
@@ -292,7 +292,7 @@ impl BrowserAction {
                 if node.node_id.inner() == &0 {
                     bail!("element not found for selector: {:?}", selector);
                 }
-                connection.post(
+                connection.send(
                     dom::SetFileInputFilesParams::builder()
                         .files(files.clone())
                         .node_id(node.node_id)
@@ -318,7 +318,7 @@ impl BrowserAction {
                         .build()
                         .map_err(|err| anyhow!(err))
                 };
-                connection.post(
+                connection.send(
                     dispatch(
                         input::DispatchMouseEventType::MousePressed,
                         *from,
@@ -337,7 +337,7 @@ impl BrowserAction {
                     if !delay.is_zero() {
                         thread::sleep(delay);
                     }
-                    connection.post(
+                    connection.send(
                         dispatch(
                             input::DispatchMouseEventType::MouseMoved,
                             point,
@@ -346,7 +346,7 @@ impl BrowserAction {
                         Some(session_id),
                     )?;
                 }
-                connection.post(
+                connection.send(
                     dispatch(
                         input::DispatchMouseEventType::MouseReleased,
                         *to,
@@ -356,7 +356,7 @@ impl BrowserAction {
                 )?;
             }
             BrowserAction::SetViewport { width, height } => {
-                connection.post(
+                connection.send(
                     emulation::SetDeviceMetricsOverrideParams::builder()
                         .width(u32::from(*width))
                         .height(u32::from(*height))


### PR DESCRIPTION
This adds an integration test and fixes a race 
where scrolls weren't fully done before we collected the next state, but continuing in the background,
leading to inaccurate state reads and action selection.